### PR TITLE
Error when mocking abstract class with no abstract methods

### DIFF
--- a/PHPUnit/Framework/MockObject/Generator.php
+++ b/PHPUnit/Framework/MockObject/Generator.php
@@ -370,7 +370,7 @@ class PHPUnit_Framework_MockObject_Generator
      * @param  boolean $callAutoload
      * @return array
      */
-    protected static function generateMock($originalClassName, array $methods, $mockClassName, $callOriginalClone, $callAutoload)
+    protected static function generateMock($originalClassName, array $methods = NULL, $mockClassName, $callOriginalClone, $callAutoload)
     {
         $templateDir   = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Generator' .
                          DIRECTORY_SEPARATOR;


### PR DESCRIPTION
When mocking an abstract class with no abstract methods using `getMockForAbstractClass()` an error occurs:

```
Argument 2 passed to PHPUnit_Framework_MockObject_Generator::generateMock() must be an
array, null given, called in /usr/share/php/PHPUnit/Framework/MockObject/Generator.php
on line 280 and defined
```

`generateMock()` should allow `$methods` to be `null`.  This indicates no methods should be mocked (see [977](http://www.phpunit.de/ticket/977)).

This pull request fixes this by allowing `null` while still enforcing type hinting.  For more info, see the first paragraph of [type hinting](http://php.net/manual/en/language.oop5.typehinting.php).
