### PR TITLE
Uncloneable classes cleanup

### DIFF
--- a/PHPUnit/Framework/MockObject/Invocation/Static.php
+++ b/PHPUnit/Framework/MockObject/Invocation/Static.php
@@ -71,15 +71,12 @@ class PHPUnit_Framework_MockObject_Invocation_Static implements PHPUnit_Framewor
      * @var array
      */
     protected static $uncloneableClasses = array(
-      'AppendIterator',
-      'CachingIterator',
       'Closure',
       'COMPersistHelper',
       'IteratorIterator',
-      'LimitIterator',
-      'RecursiveCachingIterator',
-      'RecursiveRegexIterator',
-      'RegexIterator',
+      'RecursiveIteratorIterator',
+      'SplFileObject',
+      'PDORow',
       'ZipArchive'
     );
 


### PR DESCRIPTION
Cleaned up the list of uncloneable classes.  It now includes:
- Only base classes (refs sebastianbergmann/phpunit-mock-objects@ee82245aa3382a91dd6a)
- Classes that were previously overlooked due to bugs in `ReflectionClass::isCloneable` (see http://bugs.php.net/bug.php?id=53967).  This was pointed out by sebastianbergmann/phpunit#144.
