### PR TITLE
remove dead code in generateMock()

### DIFF
--- a/PHPUnit/Framework/MockObject/Generator.php
+++ b/PHPUnit/Framework/MockObject/Generator.php
@@ -537,18 +537,9 @@ class PHPUnit_Framework_MockObject_Generator
             $methods = array();
         }
 
-        $constructor   = NULL;
         $mockedMethods = '';
 
         if (isset($class)) {
-            if ($class->hasMethod('__construct')) {
-                $constructor = $class->getMethod('__construct');
-            }
-
-            else if ($class->hasMethod($originalClassName)) {
-                $constructor = $class->getMethod($originalClassName);
-            }
-
             foreach ($methods as $methodName) {
                 try {
                     $method = $class->getMethod($methodName);


### PR DESCRIPTION
$constructor is assigned but never used (in PHPUnit_Framework_MockObject_Generator)
