### PR TITLE
Without this change, PHPUnit throws a warning because the `getMock()` met

### DIFF
--- a/PHPUnit/Framework/MockObject/Generator.php
+++ b/PHPUnit/Framework/MockObject/Generator.php
@@ -268,7 +268,7 @@ class PHPUnit_Framework_MockObject_Generator
             }
 
             if (empty($methods)) {
-                $methods = NULL;
+                $methods = array();
             }
 
             return self::getMock(


### PR DESCRIPTION
Without this change, PHPUnit throws a warning because the `getMock()` method does a `foreach` on `null`.
