### PR TITLE
Hi, the accompanying changes to Generator.php to allow configuration of SOAPClient

### DIFF
--- a/PHPUnit/Framework/MockObject/Generator.php
+++ b/PHPUnit/Framework/MockObject/Generator.php
@@ -388,16 +388,17 @@ class PHPUnit_Framework_MockObject_Generator
      * @param  string $wsdlFile
      * @param  string $originalClassName
      * @param  array  $methods
+     * @param  array  $options
      * @return array
      */
-    public static function generateClassFromWsdl($wsdlFile, $originalClassName, array $methods = array())
+    public static function generateClassFromWsdl($wsdlFile, $originalClassName, array $methods = array(), array $options = array())
     {
         if (self::$soapLoaded === NULL) {
             self::$soapLoaded = extension_loaded('soap');
         }
 
         if (self::$soapLoaded) {
-            $client   = new SOAPClient($wsdlFile);
+            $client   = new SOAPClient($wsdlFile, $options);
             $_methods = array_unique($client->__getFunctions());
             unset($client);
 
@@ -438,6 +439,11 @@ class PHPUnit_Framework_MockObject_Generator
                     $methodsBuffer .= $methodTemplate->render();
                 }
             }
+            $optionsBuffer = 'array(';
+            foreach ($options as $key => $value) {
+                $optionsBuffer .= $key . ' => ' . $value;
+            }
+            $optionsBuffer .= ')';
 
             $classTemplate = new Text_Template(
               $templateDir . 'wsdl_class.tpl'
@@ -447,6 +453,7 @@ class PHPUnit_Framework_MockObject_Generator
               array(
                 'class_name' => $originalClassName,
                 'wsdl'       => $wsdlFile,
+                'options'    => $optionsBuffer,
                 'methods'    => $methodsBuffer
               )
             );

--- a/PHPUnit/Framework/MockObject/Generator/wsdl_class.tpl.dist
+++ b/PHPUnit/Framework/MockObject/Generator/wsdl_class.tpl.dist
@@ -2,6 +2,6 @@ class {class_name} extends SOAPClient
 {
     public function __construct($wsdl, array $options)
     {
-        parent::__construct('{wsdl}');
+        parent::__construct('{wsdl}', $options);
     }
 {methods}}


### PR DESCRIPTION
Added the $options argument to the Generator::generateMockFromWsdl method passed from TestCase::getMockFromWsdl

Summary:

So that the SOAP client can be constructed with the correct options set the additional argument is passed. This allows the SOAPClient to be tested with additional options so that non standard functionality can be used e.g. SOAP_SINGLE_ELEMENT_ARRAYS
