### PR TITLE
Remove over-agressive type hint in mock object builder

### DIFF
--- a/PHPUnit/Framework/MockObject/MockBuilder.php
+++ b/PHPUnit/Framework/MockObject/MockBuilder.php
@@ -144,10 +144,10 @@ class PHPUnit_Framework_MockObject_MockBuilder
     /**
      * Specifies the subset of methods to mock. Default is to mock all of them.
      *
-     * @param  array $methods
+     * @param  array|null $methods
      * @return PHPUnit_Framework_MockObject_MockBuilder
      */
-    public function setMethods(array $methods)
+    public function setMethods($methods)
     {
         $this->methods = $methods;
 


### PR DESCRIPTION
According to line 160 of PHPUnit/Framework/MockObject/Generator.php null is also a valid value for $methods.  Therefore, the type hint in the MockBuilder setMethods() method is overly agressive and should be removed so that the error log does not have to be cluttered with warnings.
