### PR TITLE
Pass "methods" property. Fixes #GH-74

### DIFF
--- a/PHPUnit/Framework/MockObject/MockBuilder.php
+++ b/PHPUnit/Framework/MockObject/MockBuilder.php
@@ -137,7 +137,8 @@ class PHPUnit_Framework_MockObject_MockBuilder
           $this->mockClassName,
           $this->originalConstructor,
           $this->originalClone,
-          $this->autoload
+          $this->autoload,
+          $this->methods
         );
     }
 


### PR DESCRIPTION
Pass methods property to the PHPUnit_Framework_TestCase::getMockForAbstractClass
in MockBuilder::getMockForAbstractClass function.
