### PR TITLE
Adding unique ID per mock object so that they aren’t equal (__phpunit_mockObjectId)

### DIFF
--- a/PHPUnit/Framework/MockObject/Generator.php
+++ b/PHPUnit/Framework/MockObject/Generator.php
@@ -136,6 +136,11 @@ class PHPUnit_Framework_MockObject_Generator
     protected static $soapLoaded = NULL;
 
     /**
+     * @var integer
+     */
+    protected static $mockObjectId = 0;
+
+    /**
      * Returns a mock object for the specified class.
      *
      * @param  string  $originalClassName
@@ -231,18 +236,24 @@ class PHPUnit_Framework_MockObject_Generator
         if ($callOriginalConstructor &&
             !interface_exists($originalClassName, $callAutoload)) {
             if (count($arguments) == 0) {
-                return new $className;
+                $object = new $className;
             } else {
                 $class = new ReflectionClass($className);
-                return $class->newInstanceArgs($arguments);
+                $object = $class->newInstanceArgs($arguments);
             }
         } else {
             // Use a trick to create a new object of a class
             // without invoking its constructor.
-            return unserialize(
+            $object = unserialize(
               sprintf('O:%d:"%s":0:{}', strlen($className), $className)
             );
         }
+
+        if (!isset($object->__phpunit_mockObjectId)) {
+            $object->__phpunit_mockObjectId = self::$mockObjectId++;
+        }
+
+        return $object;
     }
 
     /**

--- a/Tests/GeneratorTest.php
+++ b/Tests/GeneratorTest.php
@@ -30,6 +30,18 @@ class Framework_MockObject_GeneratorTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers PHPUnit_Framework_MockObject_Generator::getObject
+     */
+    public function testMockObjectHasUniqueIdSoThatTwoMockObjectsOfTheSameClassAreNotEqual()
+    {
+        $mock1 = PHPUnit_Framework_MockObject_Generator::getMock('stdClass');
+        $this->assertSame(0, $mock1->__phpunit_mockObjectId);
+        $mock2 = PHPUnit_Framework_MockObject_Generator::getMock('stdClass');
+        $this->assertSame(1, $mock2->__phpunit_mockObjectId);
+        $this->assertNotEquals($mock1, $mock2);
+    }
+
+    /**
      * @covers PHPUnit_Framework_MockObject_Generator::getMockForAbstractClass
      */
     public function testGetMockForAbstractClassDoesNotFailWhenFakingInterfaces()


### PR DESCRIPTION
Adds a per mock object unique ID to prevent mock object from begin equal. Otherwise this test case will succeed per default nevertheless it is faulty:

``` php
<?php
class Test extends PHPUnit_Framework_TestCase
{
    function testEqual()
    {
        $mock1 = $this->getMock('stdClass');
        $mock2 = $this->getMock('stdClass');

        $sut = $this->getMock('SplFixedArray');
        $sut->expects($this->once())
            ->method('offsetSet')
            ->with(0, $mock1);

        // This should fail
        $sut->offsetSet(0, $mock2);
    }
}
```
