### PR TITLE
Fixing verification of mock objects without specific parameter matchers

### DIFF
--- a/PHPUnit/Framework/MockObject/Matcher.php
+++ b/PHPUnit/Framework/MockObject/Matcher.php
@@ -282,8 +282,13 @@ class PHPUnit_Framework_MockObject_Matcher implements PHPUnit_Framework_MockObje
 
         try {
             $this->invocationMatcher->verify();
+
+            if ($this->parametersMatcher === NULL) {
+                $this->parametersMatcher = new PHPUnit_Framework_MockObject_Matcher_AnyParameters;
+            }
+
             $invocationIsAny = get_class($this->invocationMatcher) === 'PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount';
-            if ($this->parametersMatcher !== NULL and !$invocationIsAny) {
+            if (!$invocationIsAny) {
                 $this->parametersMatcher->verify();
             }
         }

--- a/Tests/MockObjectTest.php
+++ b/Tests/MockObjectTest.php
@@ -416,4 +416,95 @@ class Framework_MockObjectTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expectedObject, $actualArguments[0]);
         $this->assertNotSame($expectedObject, $actualArguments[0]);
     }
+
+    public function testVerificationOfMethodNameFailsWithoutParameters()
+    {
+        $mock = $this->getMock('SomeClass', array('right', 'wrong'), array(), '', TRUE, TRUE, TRUE);
+        $mock->expects($this->once())
+             ->method('right');
+
+        $mock->wrong();
+        try {
+            $mock->__phpunit_verify();
+            $this->fail('Expected exception');
+        } catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertSame(
+                "Expectation failed for method name is equal to <string:right> when invoked 1 time(s).\n"
+                . 'Method was expected to be called 1 times, actually called 0 times.',
+                $e->getMessage()
+            );
+        }
+
+        $this->resetMockObjects();
+    }
+
+    public function testVerificationOfMethodNameFailsWithParameters()
+    {
+        $mock = $this->getMock('SomeClass', array('right', 'wrong'), array(), '', TRUE, TRUE, TRUE);
+        $mock->expects($this->once())
+             ->method('right');
+
+        $mock->wrong();
+        try {
+            $mock->__phpunit_verify();
+            $this->fail('Expected exception');
+        } catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertSame(
+                "Expectation failed for method name is equal to <string:right> when invoked 1 time(s).\n"
+                . 'Method was expected to be called 1 times, actually called 0 times.',
+                $e->getMessage()
+            );
+        }
+
+        $this->resetMockObjects();
+    }
+
+    public function testVerificationOfNeverFailsWithEmptyParameters()
+    {
+        $mock = $this->getMock('SomeClass', array('right', 'wrong'), array(), '', TRUE, TRUE, TRUE);
+        $mock->expects($this->never())
+             ->method('right')
+             ->with();
+
+        try {
+            $mock->right();
+            $this->fail('Expected exception');
+        } catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertSame(
+                'SomeClass::right() was not expected to be called.',
+                $e->getMessage()
+            );
+        }
+
+        $this->resetMockObjects();
+    }
+
+    public function testVerificationOfNeverFailsWithAnyParameters()
+    {
+        $mock = $this->getMock('SomeClass', array('right', 'wrong'), array(), '', TRUE, TRUE, TRUE);
+        $mock->expects($this->never())
+             ->method('right')
+             ->withAnyParameters();
+
+        try {
+            $mock->right();
+            $this->fail('Expected exception');
+        } catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertSame(
+                'SomeClass::right() was not expected to be called.',
+                $e->getMessage()
+            );
+        }
+
+        $this->resetMockObjects();
+    }
+
+    private function resetMockObjects()
+    {
+        $refl = new ReflectionObject($this);
+        $refl = $refl->getParentClass();
+        $prop = $refl->getProperty('mockObjects');
+        $prop->setAccessible(true);
+        $prop->setValue($this, array());
+    }
 }


### PR DESCRIPTION
The attached patch fixes the wrong behavior of not verifying method names when no explicit parameters are specified. This is the reproduction case:

``` php
<?php
class Clazz
{
    public function execute()
    {}

    public function anotherMethod()
    {}
}

class Test extends PHPUnit_Framework_TestCase
{
    function testShouldFail()
    {
        $mock1 = $this->getMock('Clazz');
        $mock1->expects($this->at(0))
              ->method('execute');

        $mock1->anotherMethod();
    }

    function testActuallyFails()
    {
        $mock1 = $this->getMock('Clazz');
        $mock1->expects($this->at(0))
              ->method('execute')
              ->with();

        $mock1->execute("foo");
    }
}
```
