### PR TITLE
at() matcher improvement

### DIFF
--- a/PHPUnit/Framework/MockObject/Matcher/InvokedAtIndex.php
+++ b/PHPUnit/Framework/MockObject/Matcher/InvokedAtIndex.php
@@ -71,7 +71,14 @@ class PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex implements PHPUnit_Fra
      * @var integer
      */
     protected $currentIndex = -1;
+    
+    
+    /**
+    * @var array
+    */
 
+    protected $indexes = array();
+    
     /**
      * @param integer $sequenceIndex
      */
@@ -94,10 +101,13 @@ class PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex implements PHPUnit_Fra
      */
     public function matches(PHPUnit_Framework_MockObject_Invocation $invocation)
     {
-        $this->currentIndex++;
-
-        return $this->currentIndex == $this->sequenceIndex;
-    }
+		if (!isset($this->indexes[$invocation->methodName])) $this->indexes[$invocation->methodName] = 0;
+		else $this->indexes[$invocation->methodName]++;
+		$this->currentIndex++;
+	
+        return $this->indexes[$invocation->methodName] == $this->sequenceIndex;
+	}
+	
 
     /**
      * @param PHPUnit_Framework_MockObject_Invocation $invocation


### PR DESCRIPTION
The matcher now works far more intiutively. See https://github.com/sebastianbergmann/phpunit/issues/674 for a description of the problem.

The matcher now keeps track of calls on a per-method basis. This allows for a far more useful usage of the at() matcher as it requires tests to know less about the implementation of the code they're testing. 
