### PR TITLE
Similar mocks with different argument cloning options should not be equal

### DIFF
--- a/PHPUnit/Framework/MockObject/Generator.php
+++ b/PHPUnit/Framework/MockObject/Generator.php
@@ -382,7 +382,8 @@ class PHPUnit_Framework_MockObject_Generator
             $key = md5(
               $originalClassName .
               serialize($methods) .
-              serialize($callOriginalClone)
+              serialize($callOriginalClone) .
+              serialize($cloneArguments)
             );
 
             if (isset(self::$cache[$key])) {

--- a/Tests/MockObjectTest.php
+++ b/Tests/MockObjectTest.php
@@ -464,7 +464,22 @@ class Framework_MockObjectTest extends PHPUnit_Framework_TestCase
         $mock->doSomethingElse($expectedObject);
 
         $this->assertEquals(1, count($actualArguments));
-        $this->assertNotSame($expectedObject, $actualArguments[0]);
+        $this->assertSame($expectedObject, $actualArguments[0]);
+    }
+
+    public function testArgumentCloningOptionGeneratesUniqueMock()
+    {
+        $mockWithCloning = $this->getMockBuilder('SomeClass')
+                                ->setMethods(array('doSomethingElse'))
+                                ->enableArgumentCloning()
+                                ->getMock();
+
+        $mockWithoutCloning = $this->getMockBuilder('SomeClass')
+                                   ->setMethods(array('doSomethingElse'))
+                                   ->disableArgumentCloning()
+                                   ->getMock();
+
+        $this->assertNotEquals($mockWithCloning, $mockWithoutCloning);
     }
 
     public function testVerificationOfMethodNameFailsWithoutParameters()


### PR DESCRIPTION
The following should return different mocks:

``` php
$mockWithCloning = $this->getMockBuilder('SomeClass')
                        ->setMethods(array('doSomethingElse'))
                        ->enableArgumentCloning()
                        ->getMock();

$mockWithoutCloning = $this->getMockBuilder('SomeClass')
                           ->setMethods(array('doSomethingElse'))
                           ->disableArgumentCloning()
                           ->getMock();
```
