### PR TITLE
Minor Documentation Improvements

### DIFF
--- a/PHPUnit/Framework/MockObject/Generator.php
+++ b/PHPUnit/Framework/MockObject/Generator.php
@@ -148,6 +148,7 @@ class PHPUnit_Framework_MockObject_Generator
      * @param  boolean $cloneArguments
      * @return object
      * @throws InvalidArgumentException
+     * @throws PHPUnit_Framework_Exception
      * @since  Method available since Release 1.0.0
      */
     public static function getMock($originalClassName, $methods = array(), array $arguments = array(), $mockClassName = '', $callOriginalConstructor = TRUE, $callOriginalClone = TRUE, $callAutoload = TRUE, $cloneArguments = TRUE)
@@ -266,6 +267,7 @@ class PHPUnit_Framework_MockObject_Generator
      * @return object
      * @since  Method available since Release 1.0.0
      * @throws InvalidArgumentException
+     * @throws PHPUnit_Framework_Exception
      */
     public static function getMockForAbstractClass($originalClassName, array $arguments = array(), $mockClassName = '', $callOriginalConstructor = TRUE, $callOriginalClone = TRUE, $callAutoload = TRUE, $mockedMethods = array(), $cloneArguments = TRUE)
     {
@@ -324,6 +326,7 @@ class PHPUnit_Framework_MockObject_Generator
      * @return object
      * @since  Method available since Release 1.1.0
      * @throws InvalidArgumentException
+     * @throws PHPUnit_Framework_Exception
      */
     public static function getObjectForTrait($traitName, array $arguments = array(), $traitClassName = '', $callOriginalConstructor = TRUE, $callOriginalClone = TRUE, $callAutoload = TRUE)
     {
@@ -412,7 +415,8 @@ class PHPUnit_Framework_MockObject_Generator
      * @param  string $originalClassName
      * @param  array  $methods
      * @param  array  $options
-     * @return array
+     * @return string
+     * @throws PHPUnit_Framework_Exception
      */
     public static function generateClassFromWsdl($wsdlFile, $originalClassName, array $methods = array(), array $options = array())
     {
@@ -508,6 +512,7 @@ class PHPUnit_Framework_MockObject_Generator
      * @param  boolean    $callAutoload
      * @param  boolean    $cloneArguments
      * @return array
+     * @throws PHPUnit_Framework_Exception
      */
     protected static function generateMock($originalClassName, $methods, $mockClassName, $callOriginalClone, $callAutoload, $cloneArguments = TRUE)
     {


### PR DESCRIPTION
Minor correction to phpDoc definitions. Mote notably is the correction for the return type of PHPUnit_Framework_MockObject_Generator#generateClassFromWsdl(...). This method returns a string containing the class definition that can later be evaluated for loading the dynamically generated class, not an array.
