### PR TITLE
Invoke MockObject_Matcher_Parameters::verify only once

### DIFF
--- a/PHPUnit/Framework/MockObject/Matcher/Parameters.php
+++ b/PHPUnit/Framework/MockObject/Matcher/Parameters.php
@@ -110,9 +110,7 @@ class PHPUnit_Framework_MockObject_Matcher_Parameters extends PHPUnit_Framework_
     public function matches(PHPUnit_Framework_MockObject_Invocation $invocation)
     {
         $this->invocation = $invocation;
-        $this->verify();
-
-        return true;
+        return $this->verify();
     }
 
     /**
@@ -156,5 +154,7 @@ class PHPUnit_Framework_MockObject_Matcher_Parameters extends PHPUnit_Framework_
               )
             );
         }
+
+        return true;
     }
 }


### PR DESCRIPTION
.. which is generally fine for idempotent matches; but that's no guarantee. Besides, there's no point.

This is basically in reference to sebastianbergmann/phpunit#749 (callback() assert seems to be called incorrectly).

What is happening right now, is that the `verify()` method will throw an exception if the number of parameters in the current invocation is strictly less than the number of parameter constraints we have currently defined. That's all fine and dandy, but the `matches()` method (which also calls the `verify()`) method, disagrees. The `matches()` method, after running `verify()`, will only consider the parameters to 'match' iff the current invocation has strictly less parameters defined as compared to the number of parameter constraints we have. This, of course, makes no sense.

What happens then, though, is even more interesting -  `verify()` is called, once again. But since that one already passed, earlier on, we just merrily go on with our business, disregarding that `matches` at any point in time disagreed with `verify`.

So, to keep the semantics of `matches`, `verify` and the code that's calling them in such rapid succession intact; I propose the following:
- make `verify()` actually return a boolean, instead of being void, indicating whether verification passes; as it is supposed to
- make `matches()` return the result of `verify()`
- leave the somewhat awkward `if (!matches()) verify()` type construct intact - even though `verify` will never be called there, it sorta seems intuitive.

That way, `matches()` and `verify()` can still be invoked "standalone", but they will actually agree with one another.
