### PR TITLE
Ability to call ::method() on a Stub without calling ::expects()

### DIFF
--- a/PHPUnit/Framework/MockObject/Generator/mocked_class.tpl.dist
+++ b/PHPUnit/Framework/MockObject/Generator/mocked_class.tpl.dist
@@ -10,6 +10,13 @@
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/class.phpt
+++ b/Tests/MockObject/class.phpt
@@ -88,6 +88,13 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/class_call_parent_clone.phpt
+++ b/Tests/MockObject/class_call_parent_clone.phpt
@@ -41,6 +41,13 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/class_call_parent_constructor.phpt
+++ b/Tests/MockObject/class_call_parent_constructor.phpt
@@ -40,6 +40,13 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/class_dont_call_parent_clone.phpt
+++ b/Tests/MockObject/class_dont_call_parent_clone.phpt
@@ -40,6 +40,13 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/class_dont_call_parent_constructor.phpt
+++ b/Tests/MockObject/class_dont_call_parent_constructor.phpt
@@ -40,6 +40,13 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/class_implementing_interface_call_parent_constructor.phpt
+++ b/Tests/MockObject/class_implementing_interface_call_parent_constructor.phpt
@@ -45,6 +45,13 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/class_implementing_interface_dont_call_parent_constructor.phpt
+++ b/Tests/MockObject/class_implementing_interface_dont_call_parent_constructor.phpt
@@ -45,6 +45,13 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/class_partial.phpt
+++ b/Tests/MockObject/class_partial.phpt
@@ -67,6 +67,13 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/interface.phpt
+++ b/Tests/MockObject/interface.phpt
@@ -61,6 +61,13 @@ class MockFoo implements PHPUnit_Framework_MockObject_MockObject, Foo
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/invocation_object_clone_object.phpt
+++ b/Tests/MockObject/invocation_object_clone_object.phpt
@@ -90,6 +90,13 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/invocation_static_clone_object.phpt
+++ b/Tests/MockObject/invocation_static_clone_object.phpt
@@ -90,6 +90,13 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/namespaced_class.phpt
+++ b/Tests/MockObject/namespaced_class.phpt
@@ -91,6 +91,13 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/namespaced_class_call_parent_clone.phpt
+++ b/Tests/MockObject/namespaced_class_call_parent_clone.phpt
@@ -43,6 +43,13 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/namespaced_class_call_parent_constructor.phpt
+++ b/Tests/MockObject/namespaced_class_call_parent_constructor.phpt
@@ -42,6 +42,13 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/namespaced_class_dont_call_parent_clone.phpt
+++ b/Tests/MockObject/namespaced_class_dont_call_parent_clone.phpt
@@ -42,6 +42,13 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/namespaced_class_dont_call_parent_constructor.phpt
+++ b/Tests/MockObject/namespaced_class_dont_call_parent_constructor.phpt
@@ -42,6 +42,13 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/namespaced_class_implementing_interface_call_parent_constructor.phpt
+++ b/Tests/MockObject/namespaced_class_implementing_interface_call_parent_constructor.phpt
@@ -47,6 +47,13 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/namespaced_class_implementing_interface_dont_call_parent_constructor.phpt
+++ b/Tests/MockObject/namespaced_class_implementing_interface_dont_call_parent_constructor.phpt
@@ -47,6 +47,13 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/namespaced_class_partial.phpt
+++ b/Tests/MockObject/namespaced_class_partial.phpt
@@ -69,6 +69,13 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/namespaced_interface.phpt
+++ b/Tests/MockObject/namespaced_interface.phpt
@@ -63,6 +63,13 @@ class MockFoo implements PHPUnit_Framework_MockObject_MockObject, NS\Foo
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/nonexistent_class.phpt
+++ b/Tests/MockObject/nonexistent_class.phpt
@@ -38,6 +38,13 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/nonexistent_class_with_namespace.phpt
+++ b/Tests/MockObject/nonexistent_class_with_namespace.phpt
@@ -44,6 +44,13 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/nonexistent_class_with_namespace_starting_with_separator.phpt
+++ b/Tests/MockObject/nonexistent_class_with_namespace_starting_with_separator.phpt
@@ -44,6 +44,13 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObject/proxy.phpt
+++ b/Tests/MockObject/proxy.phpt
@@ -84,6 +84,13 @@ class ProxyFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
     public static function staticExpects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
     {
         PHPUnit_Util_DeprecatedFeature_Logger::log('The stubbing and mocking of static methods is deprecated and will be removed in PHPUnit 3.9.');

--- a/Tests/MockObjectTest.php
+++ b/Tests/MockObjectTest.php
@@ -86,6 +86,13 @@ class Framework_MockObjectTest extends PHPUnit_Framework_TestCase
              ->with('someArg');
     }
 
+    public function testMockedMethodIsNotCalledWhenMethodSpecifiedDirectlyWithParameter()
+    {
+        $mock = $this->getMock('SomeClass');
+        $mock->method('doSomethingElse')
+            ->with('someArg');
+    }
+
     public function testMockedMethodIsCalledAtLeastOnce()
     {
         $mock = $this->getMock('AnInterface');


### PR DESCRIPTION
When using a Test Double as a Stub, we don't typically care whether it is actually called. Currently the mocking library forces the test author to specify an expectation of how many times the method will be called. This makes it harder to visually scan source code to see which Doubles have expectations set, and which don't care.

This change allows calls like:

```
$stub->method('foo')->will($this->returnValue('bar'));
```

This is clearer to identify as Stubbing behaviour.
