### PR TITLE
Replaced PHP >= 5.4 array syntax

### DIFF
--- a/src/Framework/MockObject/Matcher/ConsecutiveParameters.php
+++ b/src/Framework/MockObject/Matcher/ConsecutiveParameters.php
@@ -65,12 +65,12 @@ class PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters
   /**
    * @var array
    */
-  private $_parameterGroups = [];
+  private $_parameterGroups = array();
 
   /**
    * @var array
    */
-  private $_invocations = [];
+  private $_invocations = array();
 
   /**
    * @param array $parameterGroups


### PR DESCRIPTION
Missed the field declarations. Sorry.
