### PR TITLE
Fixes 'Call-time pass-by-reference has been removed'

### DIFF
--- a/src/Framework/MockObject/Generator/proxied_method.tpl.dist
+++ b/src/Framework/MockObject/Generator/proxied_method.tpl.dist
@@ -18,5 +18,5 @@
           )
         );
 
-        return $this->__phpunit_originalObject->{method_name}({arguments_call});
+        return call_user_func_array(array($this->__phpunit_originalObject, "{method_name}"), $arguments);
     }

--- a/tests/MockObject/proxy.phpt
+++ b/tests/MockObject/proxy.phpt
@@ -53,7 +53,7 @@ class ProxyFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
           )
         );
 
-        return $this->__phpunit_originalObject->bar($foo);
+        return call_user_func_array(array($this->__phpunit_originalObject, "bar"), $arguments);
     }
 
     public function baz(Foo $foo)
@@ -75,7 +75,7 @@ class ProxyFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
           )
         );
 
-        return $this->__phpunit_originalObject->baz($foo);
+        return call_user_func_array(array($this->__phpunit_originalObject, "baz"), $arguments);
     }
 
     public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)

--- a/tests/ProxyObjectTest.php
+++ b/tests/ProxyObjectTest.php
@@ -65,4 +65,16 @@ class Framework_ProxyObjectTest extends PHPUnit_Framework_TestCase
         $foo = new Foo;
         $this->assertEquals('result', $foo->doSomething($proxy));
     }
+
+    public function testMockedMethodWithReferenceIsProxiedToOriginalMethod()
+    {
+        $proxy = $this->getMockBuilder('MethodCallbackByReference')
+                      ->enableProxyingToOriginalMethods()
+                      ->getMock();
+        $a = $b = $c = 0;
+
+        $proxy->callback($a, $b, $c);
+
+        $this->assertEquals(1, $b);
+    }
 }


### PR DESCRIPTION
When trying to proxy a method which has declared references as arguments, the generated method call uses references as well. Because [call-time pass-by-reference](http://www.php.net/manual/en/language.references.pass.php) has been removed in PHP 5.4 a fatal error occurs.

```
Fatal error: Call-time pass-by-reference has been removed in /Volumes/Work/workspace/php-vcr/vendor/phpunit/phpunit-mock-objects/src/Framework/MockObject/Generator.php(301) : eval()'d code on line 52
```

Using `call_user_func_array()` avoids calling the method with arguments by reference.
