### PR TITLE
Allow disabling constructors for classes which extend an internal one

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -269,7 +269,14 @@ class PHPUnit_Framework_MockObject_Generator
             }
         } else {
             $class = new ReflectionClass($className);
-            if ($class->isInternal() || version_compare(PHP_VERSION, '5.4.0', '<')) {
+            $parent = $class;
+            $isInternal = false;
+
+            while (false === $isInternal && false !== $parent = $parent->getParentClass()) {
+                $isInternal = false !== $parent && $parent->isInternal();
+            }
+
+            if ($isInternal || version_compare(PHP_VERSION, '5.4.0', '<')) {
                 $object = unserialize(
                     sprintf('O:%d:"%s":0:{}', strlen($className), $className)
                 );

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -148,11 +148,14 @@ class Framework_MockObject_GeneratorTest extends PHPUnit_Framework_TestCase
      */
     public function testGetMockForSingletonWithReflectionSuccess()
     {
-        // Probably, this should be moved to tests/autoload.php
-        require_once __DIR__ . '/_fixture/SingletonClass.php';
-
         $mock = $this->generator->getMock('SingletonClass', array('doSomething'), array(), '', false);
         $this->assertInstanceOf('SingletonClass', $mock);
+    }
+
+    public function testGetMockForClassExtendingInternalClass()
+    {
+        $mock = $this->generator->getMock('InternalClassExtension', array(), array(), '', false);
+        $this->assertInstanceOf('InternalClassExtension', $mock);
     }
 
     /**

--- a/tests/_fixture/InternalClassExtension.php
+++ b/tests/_fixture/InternalClassExtension.php
@@ -1,0 +1,5 @@
+<?php
+
+class InternalClassExtension extends \SplFileInfo
+{
+}

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -23,11 +23,13 @@ spl_autoload_register(
                 'framework_mockobjecttest' => '/MockObjectTest.php',
                 'framework_proxyobjecttest' => '/ProxyObjectTest.php',
                 'interfacewithstaticmethod' => '/_fixture/InterfaceWithStaticMethod.php',
+                'internalclassextension' => '/_fixture/InternalClassExtension.php',
                 'methodcallback' => '/_fixture/MethodCallback.php',
                 'methodcallbackbyreference' => '/_fixture/MethodCallbackByReference.php',
                 'mockable' => '/_fixture/Mockable.php',
                 'partialmocktestclass' => '/_fixture/PartialMockTestClass.php',
                 'someclass' => '/_fixture/SomeClass.php',
+                'singletonclass' => '/_fixture/SingletonClass.php',
                 'staticmocktestclass' => '/_fixture/StaticMockTestClass.php',
                 'traversablemocktestinterface' => '/_fixture/TraversableMockTestInterface.php'
             );


### PR DESCRIPTION
Follows changes made in #165 and finally fixes #154.
