### PR TITLE
version 2.0.9/2.1.4 breaks some test suites

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -274,15 +274,13 @@ class PHPUnit_Framework_MockObject_Generator
             $class      = new ReflectionClass($className);
             $isInternal = $this->isInternalClass($class);
 
-            if ($isInternal && !$this->unserializeHackIsSupported()) {
-                throw new PHPUnit_Framework_MockObject_RuntimeException(
-                    'Internal classes cannot be mocked without invoking their constructor in PHP ' . PHP_VERSION
-                );
-            }
-
             if ($isInternal || !$hasNewInstanceWithoutConstructor) {
                 $object = unserialize(
-                    sprintf('O:%d:"%s":0:{}', strlen($className), $className)
+                    sprintf('%s:%d:"%s":0:{}',
+                        (version_compare(PHP_VERSION, '5.4', '>') && $class->implementsInterface("Serializable") ? "C" : "O"),
+                        strlen($className),
+                        $className
+                    )
                 );
             } else {
                 $object = $class->newInstanceWithoutConstructor();
@@ -1096,19 +1094,5 @@ class PHPUnit_Framework_MockObject_Generator
         }
 
         return false;
-    }
-
-    /**
-     * @return boolean
-     * @since  Method available since Release 2.0.9
-     */
-    private function unserializeHackIsSupported()
-    {
-        if (PHP_VERSION == '5.4.29' || PHP_VERSION == '5.5.13' ||
-            version_compare(PHP_VERSION, '5.6.0-dev', '>=')) {
-            return FALSE;
-        }
-
-        return TRUE;
     }
 }


### PR DESCRIPTION
First commit just change Version check to '5.6.0-dev' (as 5.6.0 is not yet release).

With this, running phpunit for doctrine/annotations

```
There was 1 error:
1) Doctrine\Tests\Common\Annotations\PhpParserTest::testClassFileDoesNotExist
PHPUnit_Framework_MockObject_RuntimeException: Internal classes cannot be mocked without invoking their constructor in PHP 5.6.0beta4
/dev/shm/BUILD/annotations-a11349d39d85bef75a71bd69bd604ac4fb993f03/tests/Doctrine/Tests/Common/Annotations/PhpParserTest.php:46
```

Second commit use a better unserialize hack.
The regression is only for Serializable internal classes.

With this, same test suite:

```
OK (370 tests, 894 assertions)
```

Remaining case : test suite on a class extending an internal Serializable class (ex: SplDoublyLinkedList)
