### PR TITLE
implemented evaluated-flag to avoid extra evaluation

### DIFF
--- a/src/Framework/MockObject/Invocation/Object.php
+++ b/src/Framework/MockObject/Invocation/Object.php
@@ -61,6 +61,11 @@ class PHPUnit_Framework_MockObject_Invocation_Object extends PHPUnit_Framework_M
     public $object;
 
     /**
+    * @var boolean
+    */
+    public $evaluated;
+
+    /**
      * @param string $className
      * @param string $methodname
      * @param array  $parameters
@@ -71,5 +76,6 @@ class PHPUnit_Framework_MockObject_Invocation_Object extends PHPUnit_Framework_M
     {
         parent::__construct($className, $methodName, $parameters, $cloneObjects);
         $this->object = $object;
+        $this->evaluated = false;
     }
 }

--- a/src/Framework/MockObject/Invocation/Static.php
+++ b/src/Framework/MockObject/Invocation/Static.php
@@ -98,6 +98,11 @@ class PHPUnit_Framework_MockObject_Invocation_Static implements PHPUnit_Framewor
     public $parameters;
 
     /**
+     * @var boolean
+     */
+    public $evaluated;
+
+    /**
      * @param string  $className
      * @param string  $methodname
      * @param array   $parameters
@@ -108,6 +113,7 @@ class PHPUnit_Framework_MockObject_Invocation_Static implements PHPUnit_Framewor
         $this->className  = $className;
         $this->methodName = $methodName;
         $this->parameters = $parameters;
+        $this->evaluated = false;
 
         if (!$cloneObjects) {
             return;

--- a/src/Framework/MockObject/Matcher/Parameters.php
+++ b/src/Framework/MockObject/Matcher/Parameters.php
@@ -142,6 +142,16 @@ class PHPUnit_Framework_MockObject_Matcher_Parameters extends PHPUnit_Framework_
             );
         }
 
+        // initialize evaluated-flag if necessary
+        if (!isset($this->invocation->evaluated)) {
+            $this->invocation->evaluated = false;
+        }
+
+        // do not evaluate parameters twice
+        if ($this->invocation->evaluated) {
+            return true;
+        }
+
         foreach ($this->parameters as $i => $parameter) {
             $parameter->evaluate(
               $this->invocation->parameters[$i],
@@ -154,6 +164,9 @@ class PHPUnit_Framework_MockObject_Matcher_Parameters extends PHPUnit_Framework_
               )
             );
         }
+
+        // mark as evaluated
+        $this->invocation->evaluated = true;
 
         return true;
     }


### PR DESCRIPTION
Hey there!

Picture the following scenario:

``` php
class PhpUnitTest extends \PHPUnit_Framework_TestCase
{
    public function testDblEval()
    {
        $bar = $this->getMockBuilder('Bar')
            ->setMethods(array('handle'))
            ->getMock();

        $args = array ('foo', 'bar', 'bazz');
        $bar->expects($this->exactly(count($args)))
            ->method('handle')
            ->with(
                $this->callback(
                    function ($arg) use (& $args) {
                        return $arg === array_shift($args);
                    }
                )
            );

        $test = new Foo();
        $test->dispatch($bar);
    }
}

class Foo
{
    public function dispatch(Bar $handler)
    {
        $handler->handle('foo');
        $handler->handle('bar');
        $handler->handle('bazz');
    }
}

class Bar
{
    public function handle($value)
    {
        // do something
    }
}
```

This test will fail due to the very last method-call gets invoked twice:

```
vagrant@precise64:/vagrant$ bin/phpunit PhpUnitTest.php
PHPUnit 4.1.3 by Sebastian Bergmann.

Configuration read from /vagrant/phpunit.xml.dist

F

Time: 245 ms, Memory: 9.75Mb

There was 1 failure:

1) PhpUnitTest::testDblEval
Expectation failed for method name is equal to <string:handle> when invoked 3 time(s).
Parameter 0 for invocation Bar::handle('bazz') does not match expected value.
Failed asserting that 'bazz' is accepted by specified callback.

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
```

The last - 4th method-call - is triggered by the `verify()` method which is made here:
https://github.com/sebastianbergmann/phpunit-mock-objects/blob/2.1/src/Framework/MockObject/Matcher.php#L289

This PR fixes that issue although it is kind of a workaround and probably there will be better ways to solve this issue.
