### PR TITLE
Fixed: Notice "Undefined variable: parameters" if the method was called ...

### DIFF
--- a/src/Framework/MockObject/Matcher/ConsecutiveParameters.php
+++ b/src/Framework/MockObject/Matcher/ConsecutiveParameters.php
@@ -129,6 +129,9 @@ class PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters
 
       if (isset($this->_parameterGroups[$callIndex])) {
           $parameters = $this->_parameterGroups[$callIndex];
+      } else {
+        // no parameter assertion for this call index
+        return;
       }
 
       if ($invocation === NULL) {

--- a/tests/MockObject/Matcher/ConsecutiveParametersTest.php
+++ b/tests/MockObject/Matcher/ConsecutiveParametersTest.php
@@ -15,6 +15,19 @@ class Framework_MockObject_Matcher_ConsecutiveParametersTest extends PHPUnit_Fra
         $mock->foo(21, 42);
     }
 
+    public function testIntegrationWithLessAssertionsThenMethodCalls()
+    {
+        $mock = $this->getMock('stdClass', array('foo'));
+        $mock
+            ->expects($this->any())
+            ->method('foo')
+            ->withConsecutive(
+              array('bar')
+            );
+        $mock->foo('bar');
+        $mock->foo(21, 42);
+    }
+
     public function testIntegrationExpectingException()
     {
         $mock = $this->getMock('stdClass', array('foo'));


### PR DESCRIPTION
...more often then assertions defined in withConsecutive().
