### PR TITLE
extended MockObject for shortcut methods

### DIFF
--- a/src/Framework/MockObject/Generator/mocked_class.tpl.dist
+++ b/src/Framework/MockObject/Generator/mocked_class.tpl.dist
@@ -38,6 +38,16 @@
     {
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
+
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
 {method}
     public function __phpunit_setOriginalObject($originalObject)
     {

--- a/src/Framework/MockObject/Generator/mocked_class.tpl.dist
+++ b/src/Framework/MockObject/Generator/mocked_class.tpl.dist
@@ -8,6 +8,36 @@
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
+
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
 {method}
     public function __phpunit_setOriginalObject($originalObject)
     {

--- a/src/Framework/MockObject/MockObject.php
+++ b/src/Framework/MockObject/MockObject.php
@@ -66,6 +66,56 @@ interface PHPUnit_Framework_MockObject_MockObject /*extends PHPUnit_Framework_Mo
     public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher);
 
     /**
+     * Registers a new once occurring expectation in the mock object and returns the match
+     * object which can be infused with further details.
+     *
+     * @return PHPUnit_Framework_MockObject_Builder_InvocationMocker
+     */
+    public function expectsOnce();
+
+    /**
+     * Registers a new any time occurring expectation in the mock object and returns the match
+     * object which can be infused with further details.
+     *
+     * @return PHPUnit_Framework_MockObject_Builder_InvocationMocker
+     */
+    public function expectsAny();
+
+    /**
+     * Registers a new expectation occurring specific times in the mock object and returns the match
+     * object which can be infused with further details.
+     *
+     * @var int $count
+     * @return PHPUnit_Framework_MockObject_Builder_InvocationMocker
+     */
+    public function expectsExactly($count);
+
+    /**
+     * Registers a new never occurring expectation in the mock object and returns the match
+     * object which can be infused with further details.
+     *
+     * @return PHPUnit_Framework_MockObject_Builder_InvocationMocker
+     */
+    public function expectsNever();
+
+    /**
+     * Registers a new at specific sequence occurring expectation in the mock object and returns the match
+     * object which can be infused with further details.
+     *
+     * @var int $index
+     * @return PHPUnit_Framework_MockObject_Builder_InvocationMocker
+     */
+    public function expectsAt($index);
+
+    /**
+     * Registers a new at least once occurring expectation in the mock object and returns the match
+     * object which can be infused with further details.
+     *
+     * @return PHPUnit_Framework_MockObject_Builder_InvocationMocker
+     */
+    public function expectsAtLeastOnce();
+
+    /**
      * @return PHPUnit_Framework_MockObject_InvocationMocker
      * @since  Method available since Release 2.0.0
      */

--- a/src/Framework/MockObject/MockObject.php
+++ b/src/Framework/MockObject/MockObject.php
@@ -116,6 +116,24 @@ interface PHPUnit_Framework_MockObject_MockObject /*extends PHPUnit_Framework_Mo
     public function expectsAtLeastOnce();
 
     /**
+     * Registers a new at given most occurring expectation in the mock object and returns the match
+     * object which can be infused with further details.
+     *
+     * @var int $count
+     * @return PHPUnit_Framework_MockObject_Builder_InvocationMocker
+     */
+    public function expectsAtMost($count);
+
+    /**
+     * Registers a new at given least occurring expectation in the mock object and returns the match
+     * object which can be infused with further details.
+     *
+     * @var int $count
+     * @return PHPUnit_Framework_MockObject_Builder_InvocationMocker
+     */
+    public function expectsAtLeast($count);
+
+    /**
      * @return PHPUnit_Framework_MockObject_InvocationMocker
      * @since  Method available since Release 2.0.0
      */

--- a/tests/MockObject/class.phpt
+++ b/tests/MockObject/class.phpt
@@ -117,6 +117,16 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/class.phpt
+++ b/tests/MockObject/class.phpt
@@ -87,6 +87,36 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/class_call_parent_clone.phpt
+++ b/tests/MockObject/class_call_parent_clone.phpt
@@ -39,6 +39,36 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/class_call_parent_clone.phpt
+++ b/tests/MockObject/class_call_parent_clone.phpt
@@ -69,6 +69,16 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/class_call_parent_constructor.phpt
+++ b/tests/MockObject/class_call_parent_constructor.phpt
@@ -38,6 +38,36 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/class_call_parent_constructor.phpt
+++ b/tests/MockObject/class_call_parent_constructor.phpt
@@ -68,6 +68,16 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/class_dont_call_parent_clone.phpt
+++ b/tests/MockObject/class_dont_call_parent_clone.phpt
@@ -38,6 +38,36 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/class_dont_call_parent_clone.phpt
+++ b/tests/MockObject/class_dont_call_parent_clone.phpt
@@ -68,6 +68,16 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/class_dont_call_parent_constructor.phpt
+++ b/tests/MockObject/class_dont_call_parent_constructor.phpt
@@ -38,6 +38,36 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/class_dont_call_parent_constructor.phpt
+++ b/tests/MockObject/class_dont_call_parent_constructor.phpt
@@ -68,6 +68,16 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/class_implementing_interface_call_parent_constructor.phpt
+++ b/tests/MockObject/class_implementing_interface_call_parent_constructor.phpt
@@ -73,6 +73,16 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/class_implementing_interface_call_parent_constructor.phpt
+++ b/tests/MockObject/class_implementing_interface_call_parent_constructor.phpt
@@ -43,6 +43,36 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/class_implementing_interface_dont_call_parent_constructor.phpt
+++ b/tests/MockObject/class_implementing_interface_dont_call_parent_constructor.phpt
@@ -73,6 +73,16 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/class_implementing_interface_dont_call_parent_constructor.phpt
+++ b/tests/MockObject/class_implementing_interface_dont_call_parent_constructor.phpt
@@ -43,6 +43,36 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/class_partial.phpt
+++ b/tests/MockObject/class_partial.phpt
@@ -65,6 +65,36 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/class_partial.phpt
+++ b/tests/MockObject/class_partial.phpt
@@ -95,6 +95,16 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/class_with_method_named_method.phpt
+++ b/tests/MockObject/class_with_method_named_method.phpt
@@ -61,6 +61,36 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function __phpunit_setOriginalObject($originalObject)
     {
         $this->__phpunit_originalObject = $originalObject;

--- a/tests/MockObject/class_with_method_named_method.phpt
+++ b/tests/MockObject/class_with_method_named_method.phpt
@@ -91,6 +91,16 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function __phpunit_setOriginalObject($originalObject)
     {
         $this->__phpunit_originalObject = $originalObject;

--- a/tests/MockObject/interface.phpt
+++ b/tests/MockObject/interface.phpt
@@ -59,6 +59,36 @@ class MockFoo implements PHPUnit_Framework_MockObject_MockObject, Foo
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/interface.phpt
+++ b/tests/MockObject/interface.phpt
@@ -89,6 +89,16 @@ class MockFoo implements PHPUnit_Framework_MockObject_MockObject, Foo
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/invocation_object_clone_object.phpt
+++ b/tests/MockObject/invocation_object_clone_object.phpt
@@ -88,6 +88,36 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/invocation_object_clone_object.phpt
+++ b/tests/MockObject/invocation_object_clone_object.phpt
@@ -118,6 +118,16 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/namespaced_class.phpt
+++ b/tests/MockObject/namespaced_class.phpt
@@ -119,6 +119,16 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/namespaced_class.phpt
+++ b/tests/MockObject/namespaced_class.phpt
@@ -89,6 +89,36 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/namespaced_class_call_parent_clone.phpt
+++ b/tests/MockObject/namespaced_class_call_parent_clone.phpt
@@ -71,6 +71,16 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/namespaced_class_call_parent_clone.phpt
+++ b/tests/MockObject/namespaced_class_call_parent_clone.phpt
@@ -41,6 +41,36 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/namespaced_class_call_parent_constructor.phpt
+++ b/tests/MockObject/namespaced_class_call_parent_constructor.phpt
@@ -40,6 +40,36 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/namespaced_class_call_parent_constructor.phpt
+++ b/tests/MockObject/namespaced_class_call_parent_constructor.phpt
@@ -70,6 +70,16 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/namespaced_class_dont_call_parent_clone.phpt
+++ b/tests/MockObject/namespaced_class_dont_call_parent_clone.phpt
@@ -40,6 +40,36 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/namespaced_class_dont_call_parent_clone.phpt
+++ b/tests/MockObject/namespaced_class_dont_call_parent_clone.phpt
@@ -70,6 +70,16 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/namespaced_class_dont_call_parent_constructor.phpt
+++ b/tests/MockObject/namespaced_class_dont_call_parent_constructor.phpt
@@ -40,6 +40,36 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/namespaced_class_dont_call_parent_constructor.phpt
+++ b/tests/MockObject/namespaced_class_dont_call_parent_constructor.phpt
@@ -70,6 +70,16 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/namespaced_class_implementing_interface_call_parent_constructor.phpt
+++ b/tests/MockObject/namespaced_class_implementing_interface_call_parent_constructor.phpt
@@ -75,6 +75,16 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/namespaced_class_implementing_interface_call_parent_constructor.phpt
+++ b/tests/MockObject/namespaced_class_implementing_interface_call_parent_constructor.phpt
@@ -45,6 +45,36 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/namespaced_class_implementing_interface_dont_call_parent_constructor.phpt
+++ b/tests/MockObject/namespaced_class_implementing_interface_dont_call_parent_constructor.phpt
@@ -75,6 +75,16 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/namespaced_class_implementing_interface_dont_call_parent_constructor.phpt
+++ b/tests/MockObject/namespaced_class_implementing_interface_dont_call_parent_constructor.phpt
@@ -45,6 +45,36 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/namespaced_class_partial.phpt
+++ b/tests/MockObject/namespaced_class_partial.phpt
@@ -97,6 +97,16 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/namespaced_class_partial.phpt
+++ b/tests/MockObject/namespaced_class_partial.phpt
@@ -67,6 +67,36 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/namespaced_interface.phpt
+++ b/tests/MockObject/namespaced_interface.phpt
@@ -61,6 +61,36 @@ class MockFoo implements PHPUnit_Framework_MockObject_MockObject, NS\Foo
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/namespaced_interface.phpt
+++ b/tests/MockObject/namespaced_interface.phpt
@@ -91,6 +91,16 @@ class MockFoo implements PHPUnit_Framework_MockObject_MockObject, NS\Foo
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/nonexistent_class.phpt
+++ b/tests/MockObject/nonexistent_class.phpt
@@ -66,6 +66,16 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/nonexistent_class.phpt
+++ b/tests/MockObject/nonexistent_class.phpt
@@ -36,6 +36,36 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/nonexistent_class_with_namespace.phpt
+++ b/tests/MockObject/nonexistent_class_with_namespace.phpt
@@ -72,6 +72,16 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/nonexistent_class_with_namespace.phpt
+++ b/tests/MockObject/nonexistent_class_with_namespace.phpt
@@ -42,6 +42,36 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/nonexistent_class_with_namespace_starting_with_separator.phpt
+++ b/tests/MockObject/nonexistent_class_with_namespace_starting_with_separator.phpt
@@ -72,6 +72,16 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/nonexistent_class_with_namespace_starting_with_separator.phpt
+++ b/tests/MockObject/nonexistent_class_with_namespace_starting_with_separator.phpt
@@ -42,6 +42,36 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/proxy.phpt
+++ b/tests/MockObject/proxy.phpt
@@ -83,6 +83,36 @@ class ProxyFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }
 
+    public function expectsOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(1));
+    }
+
+    public function expectsAny()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount);
+    }
+
+    public function expectsExactly($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount($count));
+    }
+
+    public function expectsNever()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedCount(0));
+    }
+
+    public function expectsAt($index)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex($index));
+    }
+
+    public function expectsAtLeastOnce()
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObject/proxy.phpt
+++ b/tests/MockObject/proxy.phpt
@@ -113,6 +113,16 @@ class ProxyFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce);
     }
 
+    public function expectsAtMost($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount($count));
+    }
+
+    public function expectsAtLeast($count)
+    {
+        return $this->expects(new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount($count));
+    }
+
     public function method()
     {
         $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -64,6 +64,13 @@ class Framework_MockObjectTest extends PHPUnit_Framework_TestCase
              ->method('doSomething');
     }
 
+    public function testMockedMethodIsNeverCalledShortcut()
+    {
+        $mock = $this->getMock('AnInterface');
+        $mock->expectsNever()
+             ->method('doSomething');
+    }
+
     public function testMockedMethodIsNeverCalledWithParameter()
     {
         $mock = $this->getMock('SomeClass');
@@ -76,6 +83,14 @@ class Framework_MockObjectTest extends PHPUnit_Framework_TestCase
     {
         $mock = $this->getMock('SomeClass');
         $mock->expects($this->any())
+             ->method('doSomethingElse')
+             ->with('someArg');
+    }
+
+    public function testMockedMethodIsNotCalledWhenExpectsAnyWithParameterShortcut()
+    {
+        $mock = $this->getMock('SomeClass');
+        $mock->expectsAny()
              ->method('doSomethingElse')
              ->with('someArg');
     }
@@ -96,6 +111,15 @@ class Framework_MockObjectTest extends PHPUnit_Framework_TestCase
         $mock->doSomething();
     }
 
+    public function testMockedMethodIsCalledAtLeastOnceShortcut()
+    {
+        $mock = $this->getMock('AnInterface');
+        $mock->expectsAtLeastOnce()
+             ->method('doSomething');
+
+        $mock->doSomething();
+    }
+
     public function testMockedMethodIsCalledAtLeastOnce2()
     {
         $mock = $this->getMock('AnInterface');
@@ -106,10 +130,30 @@ class Framework_MockObjectTest extends PHPUnit_Framework_TestCase
         $mock->doSomething();
     }
 
+    public function testMockedMethodIsCalledAtLeastOnce2Shortcut()
+    {
+        $mock = $this->getMock('AnInterface');
+        $mock->expectsAtLeastOnce()
+             ->method('doSomething');
+
+        $mock->doSomething();
+        $mock->doSomething();
+    }
+
     public function testMockedMethodIsCalledAtLeastTwice()
     {
         $mock = $this->getMock('AnInterface');
         $mock->expects($this->atLeast(2))
+             ->method('doSomething');
+
+        $mock->doSomething();
+        $mock->doSomething();
+    }
+
+    public function testMockedMethodIsCalledAtLeastTwiceShortcut()
+    {
+        $mock = $this->getMock('AnInterface');
+        $mock->expectsAtLeast(2)
              ->method('doSomething');
 
         $mock->doSomething();
@@ -127,10 +171,31 @@ class Framework_MockObjectTest extends PHPUnit_Framework_TestCase
         $mock->doSomething();
     }
 
+    public function testMockedMethodIsCalledAtLeastTwice2Shortcut()
+    {
+        $mock = $this->getMock('AnInterface');
+        $mock->expectsAtLeast(2)
+             ->method('doSomething');
+
+        $mock->doSomething();
+        $mock->doSomething();
+        $mock->doSomething();
+    }
+
     public function testMockedMethodIsCalledAtMostTwice()
     {
         $mock = $this->getMock('AnInterface');
         $mock->expects($this->atMost(2))
+             ->method('doSomething');
+
+        $mock->doSomething();
+        $mock->doSomething();
+    }
+
+    public function testMockedMethodIsCalledAtMostTwiceShortcut()
+    {
+        $mock = $this->getMock('AnInterface');
+        $mock->expectsAtMost(2)
              ->method('doSomething');
 
         $mock->doSomething();
@@ -146,10 +211,28 @@ class Framework_MockObjectTest extends PHPUnit_Framework_TestCase
         $mock->doSomething();
     }
 
+    public function testMockedMethodIsCalledAtMosttTwice2Shortcut()
+    {
+        $mock = $this->getMock('AnInterface');
+        $mock->expectsAtMost(2)
+             ->method('doSomething');
+
+        $mock->doSomething();
+    }
+
     public function testMockedMethodIsCalledOnce()
     {
         $mock = $this->getMock('AnInterface');
         $mock->expects($this->once())
+             ->method('doSomething');
+
+        $mock->doSomething();
+    }
+
+    public function testMockedMethodIsCalledOnceShortcut()
+    {
+        $mock = $this->getMock('AnInterface');
+        $mock->expectsOnce()
              ->method('doSomething');
 
         $mock->doSomething();
@@ -169,6 +252,16 @@ class Framework_MockObjectTest extends PHPUnit_Framework_TestCase
     {
         $mock = $this->getMock('AnInterface');
         $mock->expects($this->exactly(2))
+             ->method('doSomething');
+
+        $mock->doSomething();
+        $mock->doSomething();
+    }
+
+    public function testMockedMethodIsCalledExactlyShortcut()
+    {
+        $mock = $this->getMock('AnInterface');
+        $mock->expectsExactly(2)
              ->method('doSomething');
 
         $mock->doSomething();


### PR DESCRIPTION
... of expactations (consistent to shortcuts for returnValues); also extended mocked_class template for new methods in Interface.

## Purpose/Discription
This is a featurerequest for having those shortcutmethods for expectations on mocks similar to the shortCuts of the returnValue (e.g. "->willReturnValue()" or "->willReturnValueMap").

## Effect/Changes in Tests

     $mock->expects($this->once())
     $mock->expects($this->any())
     $mock->expects($this->exactly(12))
     $mock->expects($this->at(12))
     $mock->expects($this->atLeastOnce())
     $mock->expects($this->never())

becomes

     $mock->expectsOnce()
     $mock->expectsAny()
     $mock->expectsExactly(12)
     $mock->expectsAt(12)
     $mock->expectsAtLeastOnce()
     $mock->expectsNever()

## The changes were tested with PHPUnit 4.1 (latest stable)
So it would be nice to appear in the next minor? :-)