### PR TITLE
[Matcher] Fix multiple verify

### DIFF
--- a/src/Framework/MockObject/Matcher.php
+++ b/src/Framework/MockObject/Matcher.php
@@ -251,7 +251,7 @@ class PHPUnit_Framework_MockObject_Matcher implements PHPUnit_Framework_MockObje
 
             $invocationIsAny = get_class($this->invocationMatcher) === 'PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount';
             $invocationIsNever = get_class($this->invocationMatcher) === 'PHPUnit_Framework_MockObject_Matcher_InvokedCount' && $this->invocationMatcher->isNever();
-            if (!$invocationIsAny && !$invocationIsNever) {
+            if (!$this->parametersMatcher->isVerified() && !$invocationIsAny && !$invocationIsNever) {
                 $this->parametersMatcher->verify();
             }
         } catch (PHPUnit_Framework_ExpectationFailedException $e) {

--- a/src/Framework/MockObject/Matcher/ConsecutiveParameters.php
+++ b/src/Framework/MockObject/Matcher/ConsecutiveParameters.php
@@ -40,6 +40,11 @@ class PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters
   private $_invocations = array();
 
   /**
+   * @var array
+   */
+  private $_verificationStack = array();
+
+  /**
    * @param array $parameterGroups
    */
   public function __construct(array $parameterGroups)
@@ -79,6 +84,8 @@ class PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters
 
   public function verify()
   {
+      parent::verify();
+
       foreach ($this->_invocations as $callIndex => $invocation) {
         $this->verifyInvocation($invocation, $callIndex);
       }
@@ -93,6 +100,11 @@ class PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters
    */
   private function verifyInvocation(PHPUnit_Framework_MockObject_Invocation $invocation, $callIndex)
   {
+      if (isset($this->_verificationStack[$callIndex])) {
+          return;
+      }
+
+      $this->_verificationStack[$callIndex] = TRUE;
 
       if (isset($this->_parameterGroups[$callIndex])) {
           $parameters = $this->_parameterGroups[$callIndex];

--- a/src/Framework/MockObject/Matcher/Parameters.php
+++ b/src/Framework/MockObject/Matcher/Parameters.php
@@ -92,6 +92,8 @@ class PHPUnit_Framework_MockObject_Matcher_Parameters extends PHPUnit_Framework_
      */
     public function verify()
     {
+        parent::verify();
+
         if ($this->invocation === NULL) {
             throw new PHPUnit_Framework_ExpectationFailedException(
               'Mocked method does not exist.'

--- a/src/Framework/MockObject/Matcher/StatelessInvocation.php
+++ b/src/Framework/MockObject/Matcher/StatelessInvocation.php
@@ -26,6 +26,8 @@
  */
 abstract class PHPUnit_Framework_MockObject_Matcher_StatelessInvocation implements PHPUnit_Framework_MockObject_Matcher_Invocation
 {
+    private $_isVerified = FALSE;
+
     /**
      * Registers the invocation $invocation in the object as being invoked.
      * This will only occur after matches() returns true which means the
@@ -58,5 +60,16 @@ abstract class PHPUnit_Framework_MockObject_Matcher_StatelessInvocation implemen
      */
     public function verify()
     {
+        $this->_isVerified = TRUE;
+    }
+
+    /**
+     * Checks if the invocation has already been verified.
+     *
+     * @return bool
+     */
+    public function isVerified()
+    {
+        return $this->_isVerified;
     }
 }


### PR DESCRIPTION
The verify method is called multiple times when there are parameters (one at the invocation time and one after the test is completed). The problem is the mock parameters can be updated during the test and so, make the last verify failing whereas the assertion has been already verified during the invocation. So, this PR introduces `isVerified` on the parameter matcher to detects if it has already verified and then, disable further verification.

Not sure it it is the way to go and covers all use cases (but it fixes mine). Feedbacks are really welcome especially if someone else have a better idea on how to fix it.