### PR TITLE
Updated the phpunit version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ocramius/instantiator": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.2.*@dev"
+        "phpunit/phpunit": "~4.2"
     },
     "suggest": {
         "ext-soap": "*"


### PR DESCRIPTION
The at dev flag isn't needed since the global minimum stability is already dev. I've also re-introduced the `~` as used in mock objects 2.1.
