### PR TITLE
A minor performance improvement when relying on getMockForAbstractClass()

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -369,8 +369,8 @@ class PHPUnit_Framework_MockObject_Generator
             $reflector = new ReflectionClass($originalClassName);
             $methods   = $mockedMethods;
 
-            foreach ($reflector->getMethods() as $method) {
-                if ($method->isAbstract() && !in_array($method->getName(), $methods)) {
+            foreach ($reflector->getMethods(ReflectionMethod::IS_ABSTRACT) as $method) {
+                if (!in_array($method->getName(), $methods)) {
                     $methods[] = $method->getName();
                 }
             }


### PR DESCRIPTION
Filtering for just abstract methods will probably be a little faster, because the number of iterations will drop and we wont have to verify if the method is abstract with ```$method->isAbstract()```.