### PR TITLE
added __phpunit_hasMatchers() to the MockObject contract

### DIFF
--- a/src/Framework/MockObject/MockObject.php
+++ b/src/Framework/MockObject/MockObject.php
@@ -49,4 +49,9 @@ interface PHPUnit_Framework_MockObject_MockObject /*extends PHPUnit_Framework_Mo
      * @throws PHPUnit_Framework_ExpectationFailedException
      */
     public function __phpunit_verify();
+
+    /**
+     * @return bool
+     */
+    public function __phpunit_hasMatchers();
 }


### PR DESCRIPTION
While implementing `PHPUnit_Framework_MockObject_MockObject` I discovered that `__phpunit_hasMatchers()` seems to miss in the contract. It's in [mocked_class.tpl.dist](https://github.com/sebastianbergmann/phpunit-mock-objects/blob/2.3.0/src/Framework/MockObject/Generator/mocked_class.tpl.dist#L26) and used in [`PHPUnit_Framework_TestCase::verifyMockObjects()`](https://github.com/sebastianbergmann/phpunit/blob/4.4.5/src/Framework/TestCase.php#L928).