### PR TITLE
Fix for #207 HHVM special exception methods should not be mocked

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -796,6 +796,7 @@ class PHPUnit_Framework_MockObject_Generator
                 $methods = array_merge($methods, get_class_methods('Iterator'));
             }
 
+            $this->maybeAddHhvmExceptionMethodsToBlacklisted($class);
             foreach ($methods as $methodName) {
                 try {
                     $method = $class->getMethod($methodName);
@@ -1126,5 +1127,17 @@ class PHPUnit_Framework_MockObject_Generator
     private function isVariadic(ReflectionParameter $parameter)
     {
         return method_exists('ReflectionParameter', 'isVariadic') && $parameter->isVariadic();
+    }
+
+    /**
+     * @param ReflectionClass $class
+     * @return null
+     */
+    private function maybeAddHhvmExceptionMethodsToBlacklisted(ReflectionClass $class)
+    {
+        if (defined('HHVM_VERSION') && ($class->isSubclassOf('Exception') || $class->isInstance(new Exception()))) {
+            $specialExceptionMethods = array('setTraceOptions' => TRUE, 'getTraceOptions' => TRUE);
+            $this->blacklistedMethodNames = array_merge($this->blacklistedMethodNames, $specialExceptionMethods);
+        }
     }
 }

--- a/tests/MockBuilderTest.php
+++ b/tests/MockBuilderTest.php
@@ -145,4 +145,21 @@ class Framework_MockBuilderTest extends PHPUnit_Framework_TestCase
                      ->disableAutoload();
         $this->assertTrue($spec instanceof PHPUnit_Framework_MockObject_MockBuilder);
     }
+
+    public function testHhvmExceptionMethodsShouldNotBeMocked()
+    {
+        if (!defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Only for HHVM');
+        }
+
+        $spec = $this->getMockBuilder('Exception');
+        $mock = $spec->getMock();
+        $this->assertTrue(method_exists($mock, 'getTraceOptions'));
+        $this->assertTrue(method_exists($mock, 'setTraceOptions'));
+
+        $spec = $this->getMockBuilder('InvalidArgumentException');
+        $mock2 = $spec->getMock();
+        $this->assertTrue(method_exists($mock2, 'getTraceOptions'));
+        $this->assertTrue(method_exists($mock2, 'setTraceOptions'));
+    }
 }

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -873,6 +873,21 @@ class Framework_MockObjectTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testHhvmExceptionMethodsShouldNotBeMocked()
+    {
+        if (!defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Only for HHVM');
+        }
+
+        $mock = $this->getMock('Exception');
+        $this->assertTrue(method_exists($mock, 'getTraceOptions'));
+        $this->assertTrue(method_exists($mock, 'setTraceOptions'));
+
+        $mock2 = $this->getMock('InvalidArgumentException');
+        $this->assertTrue(method_exists($mock2, 'getTraceOptions'));
+        $this->assertTrue(method_exists($mock2, 'setTraceOptions'));
+    }
+
     private function resetMockObjects()
     {
         $refl = new ReflectionObject($this);


### PR DESCRIPTION
Tested on HHVM stable and HHVM nightly

* Added tests in `MockBuilderTest` and `MockObjectTest` to verify that HHVM exception methods are not mocked when using HHVM.
* Added `PHPUnit_Framework_MockObject_Generator::maybeAddHhvmExceptionMethods()`.
* Changed `PHPUnit_Framework_MockObject_Generator::generateMock()` to run new method before foreaching over `$methods`