### PR TITLE
Relax #expects type hinting to allow shorter notation

### DIFF
--- a/src/Framework/MockObject/Generator/mocked_class.tpl.dist
+++ b/src/Framework/MockObject/Generator/mocked_class.tpl.dist
@@ -4,7 +4,7 @@
     private $__phpunit_originalObject;
 
 {clone}{mocked_methods}
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/src/Framework/MockObject/InvocationMocker.php
+++ b/src/Framework/MockObject/InvocationMocker.php
@@ -87,11 +87,23 @@ class PHPUnit_Framework_MockObject_InvocationMocker implements PHPUnit_Framework
     }
 
     /**
-     * @param  PHPUnit_Framework_MockObject_Matcher_Invocation       $matcher
+     * @param  mixed $matcher
      * @return PHPUnit_Framework_MockObject_Builder_InvocationMocker
+     * @throws PHPUnit_Framework_MockObject_RuntimeException
      */
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
+        if (is_null($matcher)) {
+            $matcher = new PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce;
+        } elseif (is_int($matcher)) {
+            $matcher = new PHPUnit_Framework_MockObject_Matcher_InvokedCount($matcher);
+        } elseif (!$matcher instanceof PHPUnit_Framework_MockObject_Matcher_Invocation) {
+            throw new PHPUnit_Framework_MockObject_RuntimeException(
+                'Matcher must be either a null or integer value, or a '
+                . 'PHPUnit_Framework_MockObject_Matcher_Invocation instance.'
+            );
+        }
+
         return new PHPUnit_Framework_MockObject_Builder_InvocationMocker(
           $this, $matcher
         );

--- a/src/Framework/MockObject/MockObject.php
+++ b/src/Framework/MockObject/MockObject.php
@@ -24,12 +24,16 @@ interface PHPUnit_Framework_MockObject_MockObject /*extends PHPUnit_Framework_Mo
 {
     /**
      * Registers a new expectation in the mock object and returns the match
-     * object which can be infused with further details.
+     * object which can be infused with further details. This method accepts
+     * any matcher of the type PHPUnit_Framework_MockObject_Matcher_Invocation.
+     * If no matcher is passed, the default expectation will be "at least once
+     * invocation". If an integer is passed, the expectation will be an exact
+     * invocation count.
      *
-     * @param  PHPUnit_Framework_MockObject_Matcher_Invocation       $matcher
+     * @param  mixed $matcher
      * @return PHPUnit_Framework_MockObject_Builder_InvocationMocker
      */
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher);
+    public function expects($matcher = null);
 
     /**
      * @return PHPUnit_Framework_MockObject_InvocationMocker

--- a/tests/InvocationMockerTest.php
+++ b/tests/InvocationMockerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+class InvocationMockerTest extends PHPUnit_Framework_TestCase
+{
+    public function testExpectsWithNoValueMeansAtLeastOnce()
+    {
+        $mock = $this->getMock('stdClass', array('foo'));
+        $mock->expects()->method('foo');
+        $mock->foo('bar');
+        $mock->foo('baz');
+    }
+
+    public function testExpectsWithNoValueFailsIfNoInvocation()
+    {
+        $mock = $this->getMock('stdClass', array('foo'));
+
+        try {
+            $mock->expects()->method('foo');
+            $mock->__phpunit_verify();
+        } catch (PHPUnit_Framework_ExpectationFailedException $ex) {
+            $mock->foo();
+        }
+    }
+
+    public function testExpectsWithIntegerValueMeansExactInvocationCount()
+    {
+        $mock = $this->getMock('stdClass', array('foo'));
+        $mock->expects(2)->method('foo');
+        $mock->foo('bar');
+        $mock->foo('baz');
+    }
+
+    public function testExpectsWithIntegerFailsIfNoExactInvocationCount()
+    {
+        $mock = $this->getMock('stdClass', array('foo'));
+
+        try {
+            $mock->expects(2)->method('foo');
+            $mock->foo('bar');
+            $mock->__phpunit_verify();
+        } catch (PHPUnit_Framework_ExpectationFailedException $ex) {
+            $mock->foo();
+        }
+    }
+
+    /**
+     * @expectedException PHPUnit_Framework_MockObject_RuntimeException
+     */
+    public function testExpectsThrowsOnUnexpectedMatcherType()
+    {
+        $mock = $this->getMock('stdClass', array('foo'));
+        $mock->expects('unexpected')->method('foo');
+    }
+
+    public function testExpectsAllowsMatcherInterface()
+    {
+        $mock = $this->getMock('stdClass', array('foo'));
+        $mock->expects($this->any())->method('foo');
+    }
+}

--- a/tests/MockObject/class.phpt
+++ b/tests/MockObject/class.phpt
@@ -82,7 +82,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $result;
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/class_call_parent_clone.phpt
+++ b/tests/MockObject/class_call_parent_clone.phpt
@@ -34,7 +34,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         parent::__clone();
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/class_call_parent_constructor.phpt
+++ b/tests/MockObject/class_call_parent_constructor.phpt
@@ -33,7 +33,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/class_dont_call_parent_clone.phpt
+++ b/tests/MockObject/class_dont_call_parent_clone.phpt
@@ -33,7 +33,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/class_dont_call_parent_constructor.phpt
+++ b/tests/MockObject/class_dont_call_parent_constructor.phpt
@@ -33,7 +33,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/class_implementing_interface_call_parent_constructor.phpt
+++ b/tests/MockObject/class_implementing_interface_call_parent_constructor.phpt
@@ -38,7 +38,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/class_implementing_interface_dont_call_parent_constructor.phpt
+++ b/tests/MockObject/class_implementing_interface_dont_call_parent_constructor.phpt
@@ -38,7 +38,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/class_partial.phpt
+++ b/tests/MockObject/class_partial.phpt
@@ -60,7 +60,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $result;
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/class_with_method_named_method.phpt
+++ b/tests/MockObject/class_with_method_named_method.phpt
@@ -56,7 +56,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $result;
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/class_with_method_with_variadic_arguments.phpt
+++ b/tests/MockObject/class_with_method_with_variadic_arguments.phpt
@@ -60,7 +60,7 @@ class MockFoo extends ClassWithMethodWithVariadicArguments implements PHPUnit_Fr
         return $result;
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/interface.phpt
+++ b/tests/MockObject/interface.phpt
@@ -54,7 +54,7 @@ class MockFoo implements PHPUnit_Framework_MockObject_MockObject, Foo
         return $result;
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/invocation_object_clone_object.phpt
+++ b/tests/MockObject/invocation_object_clone_object.phpt
@@ -83,7 +83,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return $result;
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/namespaced_class.phpt
+++ b/tests/MockObject/namespaced_class.phpt
@@ -84,7 +84,7 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $result;
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/namespaced_class_call_parent_clone.phpt
+++ b/tests/MockObject/namespaced_class_call_parent_clone.phpt
@@ -36,7 +36,7 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         parent::__clone();
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/namespaced_class_call_parent_constructor.phpt
+++ b/tests/MockObject/namespaced_class_call_parent_constructor.phpt
@@ -35,7 +35,7 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/namespaced_class_dont_call_parent_clone.phpt
+++ b/tests/MockObject/namespaced_class_dont_call_parent_clone.phpt
@@ -35,7 +35,7 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/namespaced_class_dont_call_parent_constructor.phpt
+++ b/tests/MockObject/namespaced_class_dont_call_parent_constructor.phpt
@@ -35,7 +35,7 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/namespaced_class_implementing_interface_call_parent_constructor.phpt
+++ b/tests/MockObject/namespaced_class_implementing_interface_call_parent_constructor.phpt
@@ -40,7 +40,7 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/namespaced_class_implementing_interface_dont_call_parent_constructor.phpt
+++ b/tests/MockObject/namespaced_class_implementing_interface_dont_call_parent_constructor.phpt
@@ -40,7 +40,7 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/namespaced_class_partial.phpt
+++ b/tests/MockObject/namespaced_class_partial.phpt
@@ -62,7 +62,7 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         return $result;
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/namespaced_interface.phpt
+++ b/tests/MockObject/namespaced_interface.phpt
@@ -56,7 +56,7 @@ class MockFoo implements PHPUnit_Framework_MockObject_MockObject, NS\Foo
         return $result;
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/nonexistent_class.phpt
+++ b/tests/MockObject/nonexistent_class.phpt
@@ -31,7 +31,7 @@ class MockFoo extends NonExistentClass implements PHPUnit_Framework_MockObject_M
         $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/nonexistent_class_with_namespace.phpt
+++ b/tests/MockObject/nonexistent_class_with_namespace.phpt
@@ -37,7 +37,7 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/nonexistent_class_with_namespace_starting_with_separator.phpt
+++ b/tests/MockObject/nonexistent_class_with_namespace_starting_with_separator.phpt
@@ -37,7 +37,7 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
         $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }

--- a/tests/MockObject/proxy.phpt
+++ b/tests/MockObject/proxy.phpt
@@ -78,7 +78,7 @@ class ProxyFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         return call_user_func_array(array($this->__phpunit_originalObject, "baz"), $arguments);
     }
 
-    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    public function expects($matcher = null)
     {
         return $this->__phpunit_getInvocationMocker()->expects($matcher);
     }


### PR DESCRIPTION
Hi,

This PR introduces a shorter notation for invocation expectations. The main ideas are:

- having a default expectation which fits most cases (here I set it to "at least once")
- allowing to pass directly an integer for exact invocation count
- letting the usual, explicit behaviour untouched

Here's an example:

```php
$mock->expects()->method('foo'); // at least one invocation of "foo" is expected

$mock->expects(3)->method('foo'); // exactly three invocations required

$mock->expects($this->any())->method('foo'); // as usual...
```

This notation and the chosen default seem quite natural to me, but feel free to discuss it. I had to relax the type hinting on the `MockObject#expects` to allow this behaviour, so a bunch of test files had to be modified... I added a test case and the whole suite is green.
