### PR TITLE
Use WSDL_CACHE_NONE to disable wsdl caching

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -544,7 +544,7 @@ class PHPUnit_Framework_MockObject_Generator
         }
 
         if ($this->soapLoaded) {
-            $options = array_merge($options, array('cache_wsdl'=>FALSE));
+            $options = array_merge($options, array('cache_wsdl' => WSDL_CACHE_NONE));
             $client   = new SoapClient($wsdlFile, $options);
             $_methods = array_unique($client->__getFunctions());
             unset($client);


### PR DESCRIPTION
We experienced problems with testing new versions of a wsdl file, which had to do with not using the defined SOAP constants in PHP to disable using the cached file.