### PR TITLE
Improve error message for getMock's invalid $methods argument

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -153,7 +153,7 @@ class PHPUnit_Framework_MockObject_Generator
         }
 
         if (!is_array($methods) && !is_null($methods)) {
-            throw new InvalidArgumentException;
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'array', $methods);
         }
 
         if ($type === 'Traversable' || $type === '\\Traversable') {


### PR DESCRIPTION
Now gives better error message:
```
There was 1 error:

1) ExampleTest::testExample
PHPUnit_Framework_Exception: Argument #2 (string#__construct)of PHPUnit_Framework_MockObject_Generator::getMock() must be a array

/<path>/ExampleTest.php:8
```

Instead of:
```
There was 1 error:

1) ExampleTest::testExample
InvalidArgumentException: 

/<path>/ExampleTest.php:8
```