### PR TITLE
Type hinting for MockBuilder::setMethods()

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -153,7 +153,7 @@ class PHPUnit_Framework_MockObject_Generator
         }
 
         if (!is_array($methods) && !is_null($methods)) {
-            throw new InvalidArgumentException;
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'array', $methods);
         }
 
         if ($type === 'Traversable' || $type === '\\Traversable') {

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -151,7 +151,7 @@ class PHPUnit_Framework_MockObject_MockBuilder
      * @param  array|null                               $methods
      * @return PHPUnit_Framework_MockObject_MockBuilder
      */
-    public function setMethods($methods)
+    public function setMethods(array $methods = null)
     {
         $this->methods = $methods;
 


### PR DESCRIPTION
I know, it changes the API, because now it is possible to just call:
```
$mockBuilder->setMethods();
```
Well, maybe it is OK. It says "I want to set 'no' methods", which `null` does.

But comment says:
> Specifies the subset of methods to mock. **Default** is to mock all of them.

Now, *default behaviour* could be confused with *default argument value*. :/