### PR TITLE
Add explicit depepency on sebastian/exporter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "require": {
         "php": ">=5.3.3",
         "phpunit/php-text-template": "~1.2",
-        "doctrine/instantiator": "~1.0,>=1.0.2"
+        "doctrine/instantiator": "~1.0,>=1.0.2",
+        "sebastian/exporter": "~1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.4"


### PR DESCRIPTION
Really comestic... but used in src/Framework/MockObject/Invocation/Static.php

(detected by running phpcompatinfo)