### PR TITLE
Add support for return types

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -923,6 +923,12 @@ class PHPUnit_Framework_MockObject_Generator
             $reference = '';
         }
 
+        if ($this->hasReturnType($method)) {
+            $returnType = (string) $method->getReturnType();
+        } else {
+            $returnType = '';
+        }
+
         return $this->generateMockedMethodDefinition(
             $templateDir,
             $method->getDeclaringClass()->getName(),
@@ -931,6 +937,7 @@ class PHPUnit_Framework_MockObject_Generator
             $modifier,
             $this->getMethodParameters($method),
             $this->getMethodParameters($method, true),
+            $returnType,
             $reference,
             $callOriginalMethods,
             $method->isStatic()
@@ -945,12 +952,13 @@ class PHPUnit_Framework_MockObject_Generator
      * @param  string $modifier
      * @param  string $arguments_decl
      * @param  string $arguments_call
+     * @param  string $return_type
      * @param  string $reference
      * @param  bool   $callOriginalMethods
      * @param  bool   $static
      * @return string
      */
-    protected function generateMockedMethodDefinition($templateDir, $className, $methodName, $cloneArguments = true, $modifier = 'public', $arguments_decl = '', $arguments_call = '', $reference = '', $callOriginalMethods = false, $static = false)
+    protected function generateMockedMethodDefinition($templateDir, $className, $methodName, $cloneArguments = true, $modifier = 'public', $arguments_decl = '', $arguments_call = '', $return_type = '', $reference = '', $callOriginalMethods = false, $static = false)
     {
         if ($static) {
             $templateFile = 'mocked_static_method.tpl';
@@ -967,6 +975,8 @@ class PHPUnit_Framework_MockObject_Generator
             array(
             'arguments_decl'  => $arguments_decl,
             'arguments_call'  => $arguments_call,
+            'return_delim'    => $return_type ? ': ' : '',
+            'return_type'     => $return_type,
             'arguments_count' => !empty($arguments_call) ? count(explode(',', $arguments_call)) : 0,
             'class_name'      => $className,
             'method_name'     => $methodName,
@@ -1097,6 +1107,15 @@ class PHPUnit_Framework_MockObject_Generator
     private function hasType(ReflectionParameter $parameter)
     {
         return method_exists('ReflectionParameter', 'hasType') && $parameter->hasType();
+    }
+
+    /**
+     * @param  ReflectionMethod $method
+     * @return bool
+     */
+    private function hasReturnType(ReflectionMethod $method)
+    {
+        return method_exists('ReflectionMethod', 'hasReturnType') && $method->hasReturnType();
     }
 
     /**

--- a/src/Framework/MockObject/Generator/mocked_method.tpl.dist
+++ b/src/Framework/MockObject/Generator/mocked_method.tpl.dist
@@ -1,5 +1,5 @@
 
-    {modifier} function {reference}{method_name}({arguments_decl})
+    {modifier} function {reference}{method_name}({arguments_decl}){return_delim}{return_type}
     {
         $arguments = array({arguments_call});
         $count     = func_num_args();
@@ -14,7 +14,7 @@
 
         $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
-            '{class_name}', '{method_name}', $arguments, $this, {clone_arguments}
+            '{class_name}', '{method_name}', $arguments, '{return_type}', $this, {clone_arguments}
           )
         );
 

--- a/src/Framework/MockObject/Generator/mocked_static_method.tpl.dist
+++ b/src/Framework/MockObject/Generator/mocked_static_method.tpl.dist
@@ -1,5 +1,5 @@
 
-    {modifier} function {reference}{method_name}({arguments_decl})
+    {modifier} function {reference}{method_name}({arguments_decl}){return_delim}{return_type}
     {
         throw new PHPUnit_Framework_MockObject_BadMethodCallException;
     }

--- a/src/Framework/MockObject/Generator/proxied_method.tpl.dist
+++ b/src/Framework/MockObject/Generator/proxied_method.tpl.dist
@@ -1,5 +1,5 @@
 
-    {modifier} function {reference}{method_name}({arguments_decl})
+    {modifier} function {reference}{method_name}({arguments_decl}){return_delim}{return_type}
     {
         $arguments = array({arguments_call});
         $count     = func_num_args();
@@ -14,7 +14,7 @@
 
         $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
-            '{class_name}', '{method_name}', $arguments, $this, {clone_arguments}
+            '{class_name}', '{method_name}', $arguments, '{return_type}', $this, {clone_arguments}
           )
         );
 

--- a/src/Framework/MockObject/Invocation/Object.php
+++ b/src/Framework/MockObject/Invocation/Object.php
@@ -24,12 +24,13 @@ class PHPUnit_Framework_MockObject_Invocation_Object extends PHPUnit_Framework_M
      * @param string $className
      * @param string $methodname
      * @param array  $parameters
+     * @param string $returnType
      * @param object $object
      * @param object $cloneObjects
      */
-    public function __construct($className, $methodName, array $parameters, $object, $cloneObjects = false)
+    public function __construct($className, $methodName, array $parameters, $returnType, $object, $cloneObjects = false)
     {
-        parent::__construct($className, $methodName, $parameters, $cloneObjects);
+        parent::__construct($className, $methodName, $parameters, $returnType, $cloneObjects);
         $this->object = $object;
     }
 }

--- a/src/Framework/MockObject/Invocation/Static.php
+++ b/src/Framework/MockObject/Invocation/Static.php
@@ -58,16 +58,23 @@ class PHPUnit_Framework_MockObject_Invocation_Static implements PHPUnit_Framewor
     public $parameters;
 
     /**
+     * @var string
+     */
+    public $returnType;
+
+    /**
      * @param string $className
      * @param string $methodname
      * @param array  $parameters
+     * @param string $returnType
      * @param bool   $cloneObjects
      */
-    public function __construct($className, $methodName, array $parameters, $cloneObjects = false)
+    public function __construct($className, $methodName, array $parameters, $returnType, $cloneObjects = false)
     {
         $this->className  = $className;
         $this->methodName = $methodName;
         $this->parameters = $parameters;
+        $this->returnType = $returnType;
 
         if (!$cloneObjects) {
             return;
@@ -88,7 +95,7 @@ class PHPUnit_Framework_MockObject_Invocation_Static implements PHPUnit_Framewor
         $exporter = new Exporter;
 
         return sprintf(
-            '%s::%s(%s)',
+            '%s::%s(%s)%s',
             $this->className,
             $this->methodName,
             implode(
@@ -97,7 +104,8 @@ class PHPUnit_Framework_MockObject_Invocation_Static implements PHPUnit_Framewor
                     array($exporter, 'shortenedExport'),
                     $this->parameters
                 )
-            )
+            ),
+            $this->returnType ? sprintf(': %s', $this->returnType) : ''
         );
     }
 

--- a/src/Framework/MockObject/Matcher.php
+++ b/src/Framework/MockObject/Matcher.php
@@ -168,8 +168,8 @@ class PHPUnit_Framework_MockObject_Matcher implements PHPUnit_Framework_MockObje
                 return $generator();
 
             default:
-                return (new PHPUnit_Framework_MockObject_Generator())
-                    ->getMock($invocation->returnType);
+                $generator = new PHPUnit_Framework_MockObject_Generator();
+                return $generator->getMock($invocation->returnType);
         }
     }
 

--- a/src/Framework/MockObject/Matcher.php
+++ b/src/Framework/MockObject/Matcher.php
@@ -149,7 +149,28 @@ class PHPUnit_Framework_MockObject_Matcher implements PHPUnit_Framework_MockObje
             return $this->stub->invoke($invocation);
         }
 
-        return;
+        switch ($invocation->returnType) {
+            case '':       return null;
+            case 'string': return '';
+            case 'float':  return 0.0;
+            case 'int':    return 0;
+            case 'bool':   return false;
+            case 'array':  return array();
+
+            case 'callable':
+            case 'Closure':
+                return function () {};
+
+            case 'Traversable':
+            case 'Generator':
+                // Remove eval() when minimum version is 5.5+
+                $generator = eval('return function () { yield; };');
+                return $generator();
+
+            default:
+                return (new PHPUnit_Framework_MockObject_Generator())
+                    ->getMock($invocation->returnType);
+        }
     }
 
     /**

--- a/tests/MockObject/232.phpt
+++ b/tests/MockObject/232.phpt
@@ -82,7 +82,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
 
         $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
-            'Foo', 'speak', $arguments, $this, TRUE
+            'Foo', 'speak', $arguments, '', $this, TRUE
           )
         );
 

--- a/tests/MockObject/Invocation/ObjectTest.php
+++ b/tests/MockObject/Invocation/ObjectTest.php
@@ -8,7 +8,8 @@ class Framework_MockObject_Invocation_ObjectTest extends PHPUnit_Framework_TestC
             'FooClass',
             'FooMethod',
             array('an_argument'),
-        new StdClass
+            'ReturnType',
+            new StdClass
         );
     }
 
@@ -18,6 +19,7 @@ class Framework_MockObject_Invocation_ObjectTest extends PHPUnit_Framework_TestC
             'FooClass',
             'FooMethod',
             array('an_argument'),
+            'ReturnType',
             new StdClass
         );
 
@@ -30,6 +32,7 @@ class Framework_MockObject_Invocation_ObjectTest extends PHPUnit_Framework_TestC
             'FooClass',
             'FooMethod',
             array('an_argument'),
+            'ReturnType',
             new StdClass
         );
 
@@ -44,6 +47,7 @@ class Framework_MockObject_Invocation_ObjectTest extends PHPUnit_Framework_TestC
             'FooClass',
             'FooMethod',
             array('an_argument'),
+            'ReturnType',
             $expectedObject
         );
 
@@ -60,6 +64,7 @@ class Framework_MockObject_Invocation_ObjectTest extends PHPUnit_Framework_TestC
             'FooClass',
             'FooMethod',
             $expectedParameters,
+            'ReturnType',
             new StdClass
         );
 
@@ -75,11 +80,27 @@ class Framework_MockObject_Invocation_ObjectTest extends PHPUnit_Framework_TestC
             'FooClass',
             'FooMethod',
             $parameters,
+            'ReturnType',
             new StdClass,
             $cloneObjects
         );
 
         $this->assertEquals($parameters, $invocation->parameters);
         $this->assertNotSame($parameters, $invocation->parameters);
+    }
+
+    public function testAllowToGetReturnTypeSetInConstructor()
+    {
+        $expectedReturnType = 'string';
+
+        $invocation = new PHPUnit_Framework_MockObject_Invocation_Object(
+            'FooClass',
+            'FooMethod',
+            array('an_argument'),
+            $expectedReturnType,
+            new StdClass
+        );
+
+        $this->assertSame($expectedReturnType, $invocation->returnType);
     }
 }

--- a/tests/MockObject/Invocation/StaticTest.php
+++ b/tests/MockObject/Invocation/StaticTest.php
@@ -4,19 +4,34 @@ class Framework_MockObject_Invocation_StaticTest extends PHPUnit_Framework_TestC
 {
     public function testConstructorRequiresClassAndMethodAndParameters()
     {
-        new PHPUnit_Framework_MockObject_Invocation_Static('FooClass', 'FooMethod', array('an_argument'));
+        new PHPUnit_Framework_MockObject_Invocation_Static(
+            'FooClass',
+            'FooMethod',
+            array('an_argument'),
+            'ReturnType'
+        );
     }
 
     public function testAllowToGetClassNameSetInConstructor()
     {
-        $invocation = new PHPUnit_Framework_MockObject_Invocation_Static('FooClass', 'FooMethod', array('an_argument'));
+        $invocation = new PHPUnit_Framework_MockObject_Invocation_Static(
+            'FooClass',
+            'FooMethod',
+            array('an_argument'),
+            'ReturnType'
+        );
 
         $this->assertSame('FooClass', $invocation->className);
     }
 
     public function testAllowToGetMethodNameSetInConstructor()
     {
-        $invocation = new PHPUnit_Framework_MockObject_Invocation_Static('FooClass', 'FooMethod', array('an_argument'));
+        $invocation = new PHPUnit_Framework_MockObject_Invocation_Static(
+            'FooClass',
+            'FooMethod',
+            array('an_argument'),
+            'ReturnType'
+        );
 
         $this->assertSame('FooMethod', $invocation->methodName);
     }
@@ -30,7 +45,8 @@ class Framework_MockObject_Invocation_StaticTest extends PHPUnit_Framework_TestC
         $invocation = new PHPUnit_Framework_MockObject_Invocation_Static(
             'FooClass',
             'FooMethod',
-            $expectedParameters
+            $expectedParameters,
+            'ReturnType'
         );
 
         $this->assertSame($expectedParameters, $invocation->parameters);
@@ -45,10 +61,26 @@ class Framework_MockObject_Invocation_StaticTest extends PHPUnit_Framework_TestC
             'FooClass',
             'FooMethod',
             $parameters,
+            'ReturnType',
             $cloneObjects
         );
 
         $this->assertEquals($parameters, $invocation->parameters);
         $this->assertNotSame($parameters, $invocation->parameters);
     }
+
+    public function testAllowToGetReturnTypeSetInConstructor()
+    {
+        $expectedReturnType = 'string';
+
+        $invocation = new PHPUnit_Framework_MockObject_Invocation_Static(
+            'FooClass',
+            'FooMethod',
+            array('an_argument'),
+            $expectedReturnType
+        );
+
+        $this->assertSame($expectedReturnType, $invocation->returnType);
+    }
+
 }

--- a/tests/MockObject/abstract_class.phpt
+++ b/tests/MockObject/abstract_class.phpt
@@ -53,7 +53,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
 
         $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
-            'Foo', 'one', $arguments, $this, TRUE
+            'Foo', 'one', $arguments, '', $this, TRUE
           )
         );
 
@@ -75,7 +75,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
 
         $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
-            'Foo', 'two', $arguments, $this, TRUE
+            'Foo', 'two', $arguments, '', $this, TRUE
           )
         );
 
@@ -97,7 +97,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
 
         $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
-            'Foo', 'three', $arguments, $this, TRUE
+            'Foo', 'three', $arguments, '', $this, TRUE
           )
         );
 

--- a/tests/MockObject/class.phpt
+++ b/tests/MockObject/class.phpt
@@ -53,7 +53,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
 
         $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
-            'Foo', 'bar', $arguments, $this, TRUE
+            'Foo', 'bar', $arguments, '', $this, TRUE
           )
         );
 
@@ -75,7 +75,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
 
         $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
-            'Foo', 'baz', $arguments, $this, TRUE
+            'Foo', 'baz', $arguments, '', $this, TRUE
           )
         );
 

--- a/tests/MockObject/class_partial.phpt
+++ b/tests/MockObject/class_partial.phpt
@@ -53,7 +53,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
 
         $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
-            'Foo', 'bar', $arguments, $this, TRUE
+            'Foo', 'bar', $arguments, '', $this, TRUE
           )
         );
 

--- a/tests/MockObject/class_with_method_named_method.phpt
+++ b/tests/MockObject/class_with_method_named_method.phpt
@@ -49,7 +49,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
 
         $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
-            'Foo', 'method', $arguments, $this, TRUE
+            'Foo', 'method', $arguments, '', $this, TRUE
           )
         );
 

--- a/tests/MockObject/class_with_method_with_variadic_arguments.phpt
+++ b/tests/MockObject/class_with_method_with_variadic_arguments.phpt
@@ -53,7 +53,7 @@ class MockFoo extends ClassWithMethodWithVariadicArguments implements PHPUnit_Fr
 
         $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
-            'ClassWithMethodWithVariadicArguments', 'methodWithVariadicArguments', $arguments, $this, TRUE
+            'ClassWithMethodWithVariadicArguments', 'methodWithVariadicArguments', $arguments, '', $this, TRUE
           )
         );
 

--- a/tests/MockObject/interface.phpt
+++ b/tests/MockObject/interface.phpt
@@ -47,7 +47,7 @@ class MockFoo implements PHPUnit_Framework_MockObject_MockObject, Foo
 
         $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
-            'Foo', 'bar', $arguments, $this, TRUE
+            'Foo', 'bar', $arguments, '', $this, TRUE
           )
         );
 

--- a/tests/MockObject/invocation_object_clone_object.phpt
+++ b/tests/MockObject/invocation_object_clone_object.phpt
@@ -54,7 +54,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
 
         $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
-            'Foo', 'bar', $arguments, $this, TRUE
+            'Foo', 'bar', $arguments, '', $this, TRUE
           )
         );
 
@@ -76,7 +76,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
 
         $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
-            'Foo', 'baz', $arguments, $this, TRUE
+            'Foo', 'baz', $arguments, '', $this, TRUE
           )
         );
 

--- a/tests/MockObject/namespaced_class.phpt
+++ b/tests/MockObject/namespaced_class.phpt
@@ -55,7 +55,7 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
 
         $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
-            'NS\Foo', 'bar', $arguments, $this, TRUE
+            'NS\Foo', 'bar', $arguments, '', $this, TRUE
           )
         );
 
@@ -77,7 +77,7 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
 
         $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
-            'NS\Foo', 'baz', $arguments, $this, TRUE
+            'NS\Foo', 'baz', $arguments, '', $this, TRUE
           )
         );
 

--- a/tests/MockObject/namespaced_class_partial.phpt
+++ b/tests/MockObject/namespaced_class_partial.phpt
@@ -55,7 +55,7 @@ class MockFoo extends NS\Foo implements PHPUnit_Framework_MockObject_MockObject
 
         $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
-            'NS\Foo', 'bar', $arguments, $this, TRUE
+            'NS\Foo', 'bar', $arguments, '', $this, TRUE
           )
         );
 

--- a/tests/MockObject/namespaced_interface.phpt
+++ b/tests/MockObject/namespaced_interface.phpt
@@ -49,7 +49,7 @@ class MockFoo implements PHPUnit_Framework_MockObject_MockObject, NS\Foo
 
         $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
-            'NS\Foo', 'bar', $arguments, $this, TRUE
+            'NS\Foo', 'bar', $arguments, '', $this, TRUE
           )
         );
 

--- a/tests/MockObject/return_type_declarations_object_method.phpt
+++ b/tests/MockObject/return_type_declarations_object_method.phpt
@@ -1,15 +1,16 @@
 --TEST--
-PHPUnit_Framework_MockObject_Generator::generate('Foo', NULL, 'ProxyFoo', TRUE, TRUE, TRUE, TRUE)
+PHPUnit_Framework_MockObject_Generator::generate('Foo', array(), 'MockFoo', TRUE, TRUE)
+--SKIPIF--
+<?php
+if (!method_exists('ReflectionMethod', 'getReturnType')) print 'skip: PHP >= 7.0.0 required';
+?>
 --FILE--
 <?php
 class Foo
 {
-    public function bar(Foo $foo)
+    public function bar(string $baz): Bar
     {
-    }
-
-    public function baz(Foo $foo)
-    {
+        return 'test';
     }
 }
 
@@ -18,13 +19,17 @@ require __DIR__ . '/../../vendor/autoload.php';
 $generator = new PHPUnit_Framework_MockObject_Generator;
 
 $mock = $generator->generate(
-  'Foo', array(), 'ProxyFoo', TRUE, TRUE, TRUE, TRUE
+  'Foo',
+  array(),
+  'MockFoo',
+  TRUE,
+  TRUE
 );
 
 print $mock['code'];
 ?>
 --EXPECTF--
-class ProxyFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
+class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
 {
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
@@ -34,9 +39,9 @@ class ProxyFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
     }
 
-    public function bar(Foo $foo)
+    public function bar(string $baz): Bar
     {
-        $arguments = array($foo);
+        $arguments = array($baz);
         $count     = func_num_args();
 
         if ($count > 1) {
@@ -47,35 +52,13 @@ class ProxyFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
             }
         }
 
-        $this->__phpunit_getInvocationMocker()->invoke(
+        $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
-            'Foo', 'bar', $arguments, '', $this, TRUE
+            'Foo', 'bar', $arguments, 'Bar', $this, TRUE
           )
         );
 
-        return call_user_func_array(array($this->__phpunit_originalObject, "bar"), $arguments);
-    }
-
-    public function baz(Foo $foo)
-    {
-        $arguments = array($foo);
-        $count     = func_num_args();
-
-        if ($count > 1) {
-            $_arguments = func_get_args();
-
-            for ($i = 1; $i < $count; $i++) {
-                $arguments[] = $_arguments[$i];
-            }
-        }
-
-        $this->__phpunit_getInvocationMocker()->invoke(
-          new PHPUnit_Framework_MockObject_Invocation_Object(
-            'Foo', 'baz', $arguments, '', $this, TRUE
-          )
-        );
-
-        return call_user_func_array(array($this->__phpunit_originalObject, "baz"), $arguments);
+        return $result;
     }
 
     public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)

--- a/tests/MockObject/return_type_declarations_static_method.phpt
+++ b/tests/MockObject/return_type_declarations_static_method.phpt
@@ -1,15 +1,16 @@
 --TEST--
-PHPUnit_Framework_MockObject_Generator::generate('Foo', NULL, 'ProxyFoo', TRUE, TRUE, TRUE, TRUE)
+PHPUnit_Framework_MockObject_Generator::generate('Foo', array(), 'MockFoo', TRUE, TRUE)
+--SKIPIF--
+<?php
+if (!method_exists('ReflectionMethod', 'getReturnType')) print 'skip: PHP >= 7.0.0 required';
+?>
 --FILE--
 <?php
 class Foo
 {
-    public function bar(Foo $foo)
+    public static function bar(string $baz): Bar
     {
-    }
-
-    public function baz(Foo $foo)
-    {
+        return 'test';
     }
 }
 
@@ -18,13 +19,17 @@ require __DIR__ . '/../../vendor/autoload.php';
 $generator = new PHPUnit_Framework_MockObject_Generator;
 
 $mock = $generator->generate(
-  'Foo', array(), 'ProxyFoo', TRUE, TRUE, TRUE, TRUE
+  'Foo',
+  array(),
+  'MockFoo',
+  TRUE,
+  TRUE
 );
 
 print $mock['code'];
 ?>
 --EXPECTF--
-class ProxyFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
+class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
 {
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
@@ -34,48 +39,9 @@ class ProxyFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
     }
 
-    public function bar(Foo $foo)
+    public static function bar(string $baz): Bar
     {
-        $arguments = array($foo);
-        $count     = func_num_args();
-
-        if ($count > 1) {
-            $_arguments = func_get_args();
-
-            for ($i = 1; $i < $count; $i++) {
-                $arguments[] = $_arguments[$i];
-            }
-        }
-
-        $this->__phpunit_getInvocationMocker()->invoke(
-          new PHPUnit_Framework_MockObject_Invocation_Object(
-            'Foo', 'bar', $arguments, '', $this, TRUE
-          )
-        );
-
-        return call_user_func_array(array($this->__phpunit_originalObject, "bar"), $arguments);
-    }
-
-    public function baz(Foo $foo)
-    {
-        $arguments = array($foo);
-        $count     = func_num_args();
-
-        if ($count > 1) {
-            $_arguments = func_get_args();
-
-            for ($i = 1; $i < $count; $i++) {
-                $arguments[] = $_arguments[$i];
-            }
-        }
-
-        $this->__phpunit_getInvocationMocker()->invoke(
-          new PHPUnit_Framework_MockObject_Invocation_Object(
-            'Foo', 'baz', $arguments, '', $this, TRUE
-          )
-        );
-
-        return call_user_func_array(array($this->__phpunit_originalObject, "baz"), $arguments);
+        throw new PHPUnit_Framework_MockObject_BadMethodCallException;
     }
 
     public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)

--- a/tests/MockObject/scalar_type_declarations.phpt
+++ b/tests/MockObject/scalar_type_declarations.phpt
@@ -53,7 +53,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
 
         $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
-            'Foo', 'bar', $arguments, $this, TRUE
+            'Foo', 'bar', $arguments, '', $this, TRUE
           )
         );
 


### PR DESCRIPTION
This PR adds support for return types on mocked object methods while maintaining compatibility with older PHP versions.

If a return type is declared on a method and no return value stub has been provided, a return value is automatically generated based on the declared type. This includes creating a new mock object to return if necessary.