### PR TITLE
Improve return value generation

### DIFF
--- a/src/Framework/MockObject/Invocation.php
+++ b/src/Framework/MockObject/Invocation.php
@@ -15,4 +15,8 @@
  */
 interface PHPUnit_Framework_MockObject_Invocation
 {
+    /**
+     * @return mixed Mocked return value.
+     */
+    public function generateReturnValue();
 }

--- a/src/Framework/MockObject/Invocation/Static.php
+++ b/src/Framework/MockObject/Invocation/Static.php
@@ -110,6 +110,36 @@ class PHPUnit_Framework_MockObject_Invocation_Static implements PHPUnit_Framewor
     }
 
     /**
+     * @return mixed Mocked return value.
+     */
+    public function generateReturnValue()
+    {
+        switch ($this->returnType) {
+            case '':       return;
+            case 'string': return '';
+            case 'float':  return 0.0;
+            case 'int':    return 0;
+            case 'bool':   return false;
+            case 'array':  return [];
+
+            case 'callable':
+            case 'Closure':
+                return function () {};
+
+            case 'Traversable':
+            case 'Generator':
+                $generator = function () { yield; };
+
+                return $generator();
+
+            default:
+                $generator = new PHPUnit_Framework_MockObject_Generator;
+
+                return $generator->getMock($this->returnType);
+        }
+    }
+
+    /**
      * @param  object $original
      * @return object
      */

--- a/src/Framework/MockObject/InvocationMocker.php
+++ b/src/Framework/MockObject/InvocationMocker.php
@@ -126,7 +126,11 @@ class PHPUnit_Framework_MockObject_InvocationMocker implements PHPUnit_Framework
             throw $exception;
         }
 
-        return $returnValue;
+        if ($hasReturnValue) {
+            return $returnValue;
+        }
+
+        return $invocation->generateReturnValue();
     }
 
     /**

--- a/src/Framework/MockObject/Matcher.php
+++ b/src/Framework/MockObject/Matcher.php
@@ -149,29 +149,7 @@ class PHPUnit_Framework_MockObject_Matcher implements PHPUnit_Framework_MockObje
             return $this->stub->invoke($invocation);
         }
 
-        switch ($invocation->returnType) {
-            case '':       return;
-            case 'string': return '';
-            case 'float':  return 0.0;
-            case 'int':    return 0;
-            case 'bool':   return false;
-            case 'array':  return [];
-
-            case 'callable':
-            case 'Closure':
-                return function () {};
-
-            case 'Traversable':
-            case 'Generator':
-                $generator = function () { yield; };
-
-                return $generator();
-
-            default:
-                $generator = new PHPUnit_Framework_MockObject_Generator;
-
-                return $generator->getMock($invocation->returnType);
-        }
+        return $invocation->generateReturnValue();
     }
 
     /**


### PR DESCRIPTION
After using the updated library, I realized that a mock method without any expectations was still returning `null`. This PR fixes that problem, generating a return value even if no invocation match is found.