### PR TITLE
Fix blacklisted methods for seven

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -34,7 +34,7 @@ class PHPUnit_Framework_MockObject_Generator
     /**
      * @var array
      */
-    protected $blacklistedMethodNames = [
+    protected $legacyBlacklistedMethodNames = [
       '__CLASS__'       => true,
       '__DIR__'         => true,
       '__FILE__'        => true,
@@ -110,6 +110,22 @@ class PHPUnit_Framework_MockObject_Generator
       'var'             => true,
       'while'           => true,
       'xor'             => true
+    ];
+
+    /**
+     * @var array
+     */
+    protected $blacklistedMethodNames = [
+      '__CLASS__'       => true,
+      '__DIR__'         => true,
+      '__FILE__'        => true,
+      '__FUNCTION__'    => true,
+      '__LINE__'        => true,
+      '__METHOD__'      => true,
+      '__NAMESPACE__'   => true,
+      '__TRAIT__'       => true,
+      '__clone'         => true,
+      '__halt_compiler' => true,
     ];
 
     /**
@@ -998,11 +1014,32 @@ class PHPUnit_Framework_MockObject_Generator
         if ($method->isConstructor() ||
             $method->isFinal() ||
             $method->isPrivate() ||
-            isset($this->blacklistedMethodNames[$method->getName()])) {
+            $this->isMethodNameBlacklisted($method->getName())) {
             return false;
         }
 
         return true;
+    }
+
+    /**
+     * Returns whether i method name is blacklisted
+     *
+     * Since PHP 7 the only names that are still reserved for method names are the ones that start with an underscore
+     *
+     * @param string   $name
+     * @return boolean
+     */
+    protected function isMethodNameBlacklisted($name)
+    {
+        if (PHP_MAJOR_VERSION < 7 && isset($this->legacyBlacklistedMethodNames[$name])) {
+            return true;
+        }
+
+        if (PHP_MAJOR_VERSION >= 7 && isset($this->blacklistedMethodNames[$name])) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -40,6 +40,27 @@ class Framework_MockObject_GeneratorTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers PHPUnit_Framework_MockObject_Generator::getMock
+     * @covers PHPUnit_Framework_MockObject_Generator::isMethodNameBlacklisted
+     */
+    public function testGetMockBlacklistedMethodNamesPhp7()
+    {
+        if (PHP_MAJOR_VERSION < 7) {
+            $this->markTestSkipped('PHP >= 7.0.0 required');
+
+            return;
+        }
+
+        // Probably, this should be moved to tests/autoload.php
+        require_once __DIR__ . '/_fixture/InterfaceWithSemiReservedMethodName.php';
+
+        $mock = $this->generator->getMock('InterfaceWithSemiReservedMethodName');
+
+        $this->assertTrue(method_exists($mock, 'unset'));
+        $this->assertInstanceOf('InterfaceWithSemiReservedMethodName', $mock);
+    }
+
+    /**
      * @covers PHPUnit_Framework_MockObject_Generator::getMockForAbstractClass
      */
     public function testGetMockForAbstractClassDoesNotFailWhenFakingInterfaces()

--- a/tests/_fixture/InterfaceWithSemiReservedMethodName.php
+++ b/tests/_fixture/InterfaceWithSemiReservedMethodName.php
@@ -1,0 +1,5 @@
+<?php
+interface InterfaceWithSemiReservedMethodName
+{
+    public function unset();
+}


### PR DESCRIPTION
When creating a mock of an interface with e.g. an `unset()` method it exits with a [fatal error](https://travis-ci.org/CodeCollab/Http/jobs/78128289#L174), because (amongst others) [the `unset` method name is blacklisted](https://github.com/sebastianbergmann/phpunit-mock-objects/blob/master/src/Framework/MockObject/Generator.php#L37-L113):

> [PHP Fatal error:  Class Mock_Session_623e1005 contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (CodeCollab\Http\Session\Session::unset) in /home/travis/build/CodeCollab/Http/vendor/phpunit/phpunit-mock-objects/src/Framework/MockObject/Generator.php(290) : eval()'d code on line 1]

[As of PHP 7 the only reserved method names are the ones starting with an underscore](https://3v4l.org/hrWfW).

This PR renames the current list of blacklisted method names from `blacklistedMethodNames` -> `legacyBlacklistedMethodNames` and re-uses the `blacklistedMethodNames` property to only include the blacklisted method names for >= 7.

The property is `protected` instead of `private` so this may be a BC break. however considering this targets a new major version (3.x) I would say this is all fair game.