### PR TITLE
Allow using Framework_Constraints when matching arguments in returnValueMap

### DIFF
--- a/src/Framework/MockObject/Stub/ReturnValueMap.php
+++ b/src/Framework/MockObject/Stub/ReturnValueMap.php
@@ -32,7 +32,7 @@ class PHPUnit_Framework_MockObject_Stub_ReturnValueMap implements PHPUnit_Framew
             }
 
             $return = array_pop($map);
-            if ($invocation->parameters === $map) {
+            if ($this->compare($invocation->parameters, $map)) {
                 return $return;
             }
         }
@@ -43,5 +43,26 @@ class PHPUnit_Framework_MockObject_Stub_ReturnValueMap implements PHPUnit_Framew
     public function toString()
     {
         return 'return value from a map';
+    }
+
+    /**
+     * @param  array $actual
+     * @param  array $expected
+     * @return bool
+     */
+    protected function compare($actual, $expected) {
+        foreach ($expected as $index => $value) {
+            if ($value instanceof PHPUnit_Framework_Constraint) {
+                if ($value->evaluate($actual[$index], '', true) === false) {
+                    return false;
+                }
+            } else {
+                if ($value !== $actual[$index]) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 }

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -206,6 +206,36 @@ class Framework_MockObjectTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(null, $mock->doSomething('foo', 'bar'));
     }
 
+    public function testStubbedReturnValueMapAcceptsConstraints() {
+        $map = [
+            [$this->equalTo(0.6666, 0.01), '2/3'],
+            [$this->equalTo(0.2856, 0.01), '2/7']
+        ];
+        $mock = $this->getMock('AnInterface');
+        $mock->expects($this->any())
+            ->method('doSomething')
+            ->will($this->returnValueMap($map));
+        $this->assertEquals('2/3', $mock->doSomething(2/3));
+        $this->assertEquals('2/7', $mock->doSomething(2/7));
+    }
+
+    public function testStubbedReturnValueMapWorksWithAnythingConstraint() {
+        $map = [
+            [$this->equalTo('a'), 'b', 'c', 'd'],
+            ['e', $this->equalTo('f'), 'g', 'h'],
+            [$this->anything(), $this->anything(), $this->anything(), 'default']
+        ];
+
+        $mock = $this->getMock('AnInterface');
+        $mock->expects($this->any())
+            ->method('doSomething')
+            ->will($this->returnValueMap($map));
+
+        $this->assertEquals('d', $mock->doSomething('a', 'b', 'c'));
+        $this->assertEquals('h', $mock->doSomething('e', 'f', 'g'));
+        $this->assertEquals('default', $mock->doSomething('foo', 'bar', 'baz'));
+    }
+
     public function testStubbedReturnArgument()
     {
         $mock = $this->getMock('AnInterface');


### PR DESCRIPTION
One thing that ReturnValueMap lacks is flexibility regarding the arguments the method was invoked with. It works only with exact match. As a side effect, if you have floats as arguments, it may fail.

I've implemented a constraint support, which may be used for workaround on the floats comparison as well (as equalsTo accepts precision). The reason I didn't implement float comparison with delta is that there's no obvious way to provide the delta, and hard-coding arbitrary delta doesn't feel right. On the other hand equalsTo solves the problem, and having Constraints as arguments gives great flexibility.