### PR TITLE
PHP Fatal Error when mocking SoapClient on PHP 5.3

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -1110,7 +1110,7 @@ class PHPUnit_Framework_MockObject_Generator
         $methods = array();
 
         foreach ($class->getMethods() as $method) {
-            if ($method->isPublic() || $method->isAbstract()) {
+            if (($method->isPublic() || $method->isAbstract()) && !in_array($method->getName(), $methods)) {
                 $methods[] = $method->getName();
             }
         }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -183,4 +183,18 @@ class Framework_MockObject_GeneratorTest extends PHPUnit_Framework_TestCase
 
         $mock = $this->generator->getMock('SingletonClass', array('doSomething'), array(), '', false);
     }
+
+    /**
+     * ReflectionClass::getMethods for SoapClient on PHP 5.3 produces PHP Fatal Error
+     * @runInSeparateProcess
+     */
+    public function testGetMockForSoapClientReflectionMethodsDuplication()
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+            $this->markTestSkipped('Only for PHP < 5.4.0');
+        }
+
+        $mock = $this->generator->getMock('SoapClient', array(), array(), '', false);
+        $this->assertInstanceOf('SoapClient', $mock);
+    }
 }


### PR DESCRIPTION
RE-opening #251 as requested when it's a bug

When mocking SoapClient on PHP 5.3 the following occurs:

PHP Fatal error: Cannot redeclare Mock_SoapClient_122a5946::__setSoapHeaders()

This is due to an issue with the ReflectionClass::getMethods on SoapClient returning an array containing duplicate entries for a few of the methods.

The array containing the duplicate entries is generated in PHPUnit_Framework_MockObject_Generator::getClassMethods due to it's dependency on ReflectionClass, hence the fix in there.

I've attached a test that ensures a class is generated without causing a fatal error in less than PHP 5.4.