### PR TITLE
Fix mocking methods with self typehint

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -1031,7 +1031,7 @@ class PHPUnit_Framework_MockObject_Generator
             $typeDeclaration = '';
 
             if (!$forCall) {
-                if ($this->hasType($parameter)) {
+                if ($this->hasType($parameter) && (string) $parameter->getType() !== 'self') {
                     $typeDeclaration = (string) $parameter->getType() . ' ';
                 } elseif ($parameter->isArray()) {
                     $typeDeclaration = 'array ';

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -831,6 +831,11 @@ class Framework_MockObjectTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testGetMockForClassWithSelfTypeHint()
+    {
+        $this->getMock('ClassWithSelfTypeHint');
+    }
+
     private function resetMockObjects()
     {
         $refl = new ReflectionObject($this);

--- a/tests/_fixture/ClassWithSelfTypeHint.php
+++ b/tests/_fixture/ClassWithSelfTypeHint.php
@@ -1,0 +1,8 @@
+<?php
+class ClassWithSelfTypeHint
+{
+    public function foo(self $foo)
+    {
+    }
+}
+


### PR DESCRIPTION
As of PHP 7, the ```getType()``` method exists, which will return ```self``` as type though. The problem with this is, that extending classes cannot define ```self``` when overriding a method.

I PRed this against 2.3 to get it fixed for PHPUnit 4.x series as well, but it should be forward-ported as well to master.