### PR TITLE
try to fix __toString mocked method

### DIFF
--- a/src/Framework/MockObject/InvocationMocker.php
+++ b/src/Framework/MockObject/InvocationMocker.php
@@ -103,6 +103,7 @@ class PHPUnit_Framework_MockObject_InvocationMocker implements PHPUnit_Framework
 
         if (strtolower($invocation->methodName) == '__tostring') {
             $returnValue = '';
+            $hasReturnValue = true;
         } else {
             $returnValue = null;
         }


### PR DESCRIPTION
Running composer test suite with PHPUnit 5.0.4 I encounter lot of failures

     1) Composer\Test\Downloader\DownloadManagerTest::testGetDownloaderForIncorrectlyInstalledPackage
     Failed asserting that exception of type "ErrorException" matches expected exception "InvalidArgumentException". Message was: "Method Mock_PackageInterface_a8c9deb9::__toString() must return a string value" at
     
     2) Composer\Test\Downloader\DownloadManagerTest::testBadPackageDownload
     Failed asserting that exception of type "ErrorException" matches expected exception "InvalidArgumentException". Message was: "Method Mock_PackageInterface_a8c9deb9::__toString() must return a string value" at
     
     3) Composer\Test\Downloader\DownloadManagerTest::testBadPackageDownloadWithSourcePreferred
     Failed asserting that exception of type "ErrorException" matches expected exception "InvalidArgumentException". Message was: "Method Mock_PackageInterface_a8c9deb9::__toString() must return a string value" at
     
     ....

This seems to fix this issue, but I'm obviously not a expert... just trying to point you to the place were the issue can be...

With this, composer test suite:

     PHPUnit 5.0.4 by Sebastian Bergmann and contributors.
    
     Runtime:       PHP 5.6.14 with Xdebug 2.3.3
     Configuration: /dev/shm/BUILD/composer-fcce52b169799fc5973d080d31c27532ca41b7b8/phpunit.xml.dist
     
     ...
     OK, but incomplete, skipped, or risky tests!
     Tests: 833, Assertions: 1636, Skipped: 2.



