### PR TITLE
toString() throwing an exception because returning null

### DIFF
--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -834,4 +834,11 @@ class Framework_MockObjectTest extends PHPUnit_Framework_TestCase
         $prop->setAccessible(true);
         $prop->setValue($this, []);
     }
+
+    public function testStringableClassDoesNotThrow()
+    {
+        $mock = $this->getMock('StringableClass');
+
+        $this->assertInternalType('string', (string) $mock);
+    }
 }

--- a/tests/_fixture/StringableClass.php
+++ b/tests/_fixture/StringableClass.php
@@ -1,0 +1,8 @@
+<?php
+class StringableClass
+{
+    public function __toString()
+    {
+        return '12345';
+    }
+}


### PR DESCRIPTION
I added a test that reproduces the problem with mocking of objects with toString() as described in #262 