### PR TITLE
Mocked interface methods that return self in PHP7 cause a fatal error

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -984,6 +984,13 @@ class PHPUnit_Framework_MockObject_Generator
             );
         }
 
+        // Mocked interfaces returning 'self' must explicitly declare the
+        // interface name as the return type. See
+        // https://bugs.php.net/bug.php?id=70722
+        if ($return_type === 'self') {
+            $return_type = $className;
+        }
+
         $template = new Text_Template($templateDir . $templateFile);
 
         $template->setVar(

--- a/tests/MockObject/return_type_declarations_self.phpt
+++ b/tests/MockObject/return_type_declarations_self.phpt
@@ -1,0 +1,100 @@
+--TEST--
+PHPUnit_Framework_MockObject_Generator::generate('Foo', array(), 'MockFoo', true, true)
+--SKIPIF--
+<?php
+if (!method_exists('ReflectionMethod', 'getReturnType')) print 'skip: PHP >= 7.0.0 required';
+?>
+--FILE--
+<?php
+interface Foo
+{
+    public function bar(string $baz): self;
+}
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$generator = new PHPUnit_Framework_MockObject_Generator;
+
+$mock = $generator->generate(
+    'Foo',
+    array(),
+    'MockFoo',
+    true,
+    true
+);
+
+print $mock['code'];
+?>
+--EXPECTF--
+class MockFoo implements PHPUnit_Framework_MockObject_MockObject, Foo
+{
+    private $__phpunit_invocationMocker;
+    private $__phpunit_originalObject;
+
+    public function __clone()
+    {
+        $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
+    }
+
+    public function bar(string $baz): Foo
+    {
+        $arguments = array($baz);
+        $count     = func_num_args();
+
+        if ($count > 1) {
+            $_arguments = func_get_args();
+
+            for ($i = 1; $i < $count; $i++) {
+                $arguments[] = $_arguments[$i];
+            }
+        }
+
+        $result = $this->__phpunit_getInvocationMocker()->invoke(
+            new PHPUnit_Framework_MockObject_Invocation_Object(
+                'Foo', 'bar', $arguments, 'Foo', $this, true
+            )
+        );
+
+        return $result;
+    }
+
+    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    {
+        return $this->__phpunit_getInvocationMocker()->expects($matcher);
+    }
+
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
+    public function __phpunit_setOriginalObject($originalObject)
+    {
+        $this->__phpunit_originalObject = $originalObject;
+    }
+
+    public function __phpunit_getInvocationMocker()
+    {
+        if ($this->__phpunit_invocationMocker === null) {
+            $this->__phpunit_invocationMocker = new PHPUnit_Framework_MockObject_InvocationMocker;
+        }
+
+        return $this->__phpunit_invocationMocker;
+    }
+
+    public function __phpunit_hasMatchers()
+    {
+        return $this->__phpunit_getInvocationMocker()->hasMatchers();
+    }
+
+    public function __phpunit_verify($unsetInvocationMocker = true)
+    {
+        $this->__phpunit_getInvocationMocker()->verify();
+
+        if ($unsetInvocationMocker) {
+            $this->__phpunit_invocationMocker = null;
+        }
+    }
+}


### PR DESCRIPTION
If an interface in PHP7 code declares a method with a `self` return type, mocking that interface fails because the `eval`'d code doesn't explicitly specify the name of the interface as the return type. Presently, the PHP team considers this to be [expected behavior](https://bugs.php.net/bug.php?id=70722); as such, I've tweaked the mock object generator output slightly.

The error was roughly as follows:
```
PHP Fatal error:  Declaration of Mock_EndpointInterface_746d0140::authenticate(): Mock_EndpointInterface_746d0140 
must be compatible with SomeInterface::authenticate(): SomeInterface 
in /Users/firehed/dev/API/vendor/phpunit/phpunit-mock-objects/src/Framework/MockObject/Generator.php(305) : eval()'d code on line 1
```

Mocked Interface:
```
interface SomeInterface {
    public function authenticate(): self;
}
```
Generated code (PHPUnit 5.0.6; mock objects 3.0.2):
```
public function authenticate(): self
{
    // ...
}
```

New output:
```
public function authenticate(): SomeInterface
{
    // ...
}