### PR TITLE
Add ability to envelope a mock over test object overriding its protected methods and making them public

### DIFF
--- a/src/Framework/MockObject/Stub/CallOriginalMethod.php
+++ b/src/Framework/MockObject/Stub/CallOriginalMethod.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Calls original method value when it is mocked be getMockOverExistingObject()
+ */
+class PHPUnit_Framework_MockObject_Stub_CallOriginalMethod implements \PHPUnit_Framework_MockObject_Stub {
+	/**
+	 * @param \PHPUnit_Framework_MockObject_Invocation_Object $invocation
+	 * @return mixed
+	 */
+	public function invoke(\PHPUnit_Framework_MockObject_Invocation $invocation) {
+		$reflection = new \ReflectionClass($invocation->className);
+		$method = $reflection->getMethod($invocation->methodName);
+		$method->setAccessible(true);
+		return $method->invokeArgs($invocation->object, $invocation->parameters);
+	}
+
+	/**
+	 * Returns a string representation of the object.
+	 *
+	 * @return string
+	 */
+	public function toString() {
+		return 'return original method value';
+	}
+}

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -180,4 +180,17 @@ class Framework_MockObject_GeneratorTest extends PHPUnit_Framework_TestCase
     {
         $this->generator->getMock(StdClass::class, [], [], '', false, true, true, true, true);
     }
+
+    /**
+     * @covers PHPUnit_Framework_MockObject_Generator::getMockOverExistingObject
+     */
+    public function testGetMockOverExistingObject() {
+        $srcObject = new ClassWithProtectedMethod();
+        $this->assertEquals('real-value', $srcObject->testMethod());
+        $mock = $this->generator->getMockOverExistingObject($srcObject, []);
+        $mock->expects($this->any())
+             ->method('mockableProtectedMethod')
+             ->willReturn('test-value');
+        $this->assertEquals('test-value', $mock->testMethod());
+    }
 }

--- a/tests/MockObject/Stub/CallOriginalMethodTest.php
+++ b/tests/MockObject/Stub/CallOriginalMethodTest.php
@@ -1,0 +1,18 @@
+<?php
+
+class Framework_MockObject_Stub_CallOriginalMethodTest extends PHPUnit_Framework_TestCase
+{
+	public function testOriginalMethodCalled()
+	{
+		$invocation = new PHPUnit_Framework_MockObject_Invocation_Object(
+			'ClassWithProtectedMethod',
+			'mockableProtectedMethod',
+			[],
+			'ReturnType',
+			$srcObj = new ClassWithProtectedMethodAncestor()
+		);
+		$this->assertEquals('overridden-value', $srcObj->mockableProtectedMethod());
+		$call = new PHPUnit_Framework_MockObject_Stub_CallOriginalMethod();
+		$this->assertEquals('real-value', $call->invoke($invocation));
+	}
+}

--- a/tests/_fixture/ClassWithProtectedMethod.php
+++ b/tests/_fixture/ClassWithProtectedMethod.php
@@ -1,0 +1,13 @@
+<?php
+
+class ClassWithProtectedMethod {
+	// Should be overridden and mocked
+	protected function mockableProtectedMethod() {
+		return 'real-value';
+	}
+
+	public function testMethod() {
+		// Should call overridden mocked method
+		return $this->mockableProtectedMethod();
+	}
+}

--- a/tests/_fixture/ClassWithProtectedMethodAncestor.php
+++ b/tests/_fixture/ClassWithProtectedMethodAncestor.php
@@ -1,0 +1,7 @@
+<?php
+
+class ClassWithProtectedMethodAncestor extends ClassWithProtectedMethod {
+	public function mockableProtectedMethod() {
+		return 'overridden-value';
+	}
+}


### PR DESCRIPTION
This simple addition is useful when testing a class with mass logic splitted into separate protected methods. For example:

class A {
    public function A() {
        $result = $this->B();
        $result = $this->C($result);
        $result = $this->D($result);
        return $result;
    }
    protected function B() {
    }
    protected function C() {
    }
    protected function D() {
    }
}

In this case we can mock methods B, C, D and test them separately. Moreover, we can mock them and return test values into the method A so we can test it using test values, avoiding to call original methods.

The idea to envelope a mock over existing object is to create on abject to test using usual way with its constructor call with code completion, type hinting and other IDE features.