### PR TITLE
Fix default return value of mocked __toString()

### DIFF
--- a/src/Framework/MockObject/Invocation/Object.php
+++ b/src/Framework/MockObject/Invocation/Object.php
@@ -33,4 +33,16 @@ class PHPUnit_Framework_MockObject_Invocation_Object extends PHPUnit_Framework_M
         parent::__construct($className, $methodName, $parameters, $returnType, $cloneObjects);
         $this->object = $object;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateReturnValue()
+    {
+        if (strtolower($this->methodName) == '__tostring') {
+            return '';
+        }
+
+        return parent::generateReturnValue();
+    }
 }

--- a/src/Framework/MockObject/InvocationMocker.php
+++ b/src/Framework/MockObject/InvocationMocker.php
@@ -100,13 +100,7 @@ class PHPUnit_Framework_MockObject_InvocationMocker implements PHPUnit_Framework
     {
         $exception      = null;
         $hasReturnValue = false;
-
-        if (strtolower($invocation->methodName) == '__tostring') {
-            $hasReturnValue = true;
-            $returnValue    = '';
-        } else {
-            $returnValue = null;
-        }
+        $returnValue    = null;
 
         foreach ($this->matchers as $match) {
             try {

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -841,4 +841,12 @@ class Framework_MockObjectTest extends PHPUnit_Framework_TestCase
 
         $this->assertInternalType('string', (string) $mock);
     }
+
+    public function testStringableClassCanBeMocked()
+    {
+        $mock = $this->getMock('StringableClass');
+        $mock->method('__toString')->willReturn('somestring');
+
+        $this->assertSame('somestring', (string) $mock);
+    }
 }


### PR DESCRIPTION
Moved the logic of detecting if it is the toString() method to
Invocation/Object. I think it is better to check there as in my 
opinion fits better as all the other default return values are 
also generated there.

I also added a test to see that mocking of toString() works.

Do you think this change is okay?

Fixes #267 