### PR TITLE
Improve on #cf6796c and fix the issue with __toString returning always an empty string

### DIFF
--- a/src/Framework/MockObject/InvocationMocker.php
+++ b/src/Framework/MockObject/InvocationMocker.php
@@ -98,15 +98,9 @@ class PHPUnit_Framework_MockObject_InvocationMocker implements PHPUnit_Framework
      */
     public function invoke(PHPUnit_Framework_MockObject_Invocation $invocation)
     {
-        $exception      = null;
-        $hasReturnValue = false;
-
-        if (strtolower($invocation->methodName) == '__tostring') {
-            $hasReturnValue = true;
-            $returnValue    = '';
-        } else {
-            $returnValue = null;
-        }
+        $exception            = null;
+        $hasReturnValue       = false;
+        $returnValue          = null;
 
         foreach ($this->matchers as $match) {
             try {
@@ -125,6 +119,14 @@ class PHPUnit_Framework_MockObject_InvocationMocker implements PHPUnit_Framework
 
         if ($exception !== null) {
             throw $exception;
+        }
+
+        if ((strtolower($invocation->methodName) === '__tostring')) {
+            if ($returnValue) {
+                return $returnValue->invoke($invocation);
+            }
+
+            return '';
         }
 
         if ($hasReturnValue) {

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -841,4 +841,12 @@ class Framework_MockObjectTest extends PHPUnit_Framework_TestCase
 
         $this->assertInternalType('string', (string) $mock);
     }
+
+    public function testToStringMatcherWillReturnThegivenValue()
+    {
+        $mock = $this->getMock('StringableClass');
+        $mock->expects($this->any())->method('__toString')->willReturn($this->returnValue('another_string'));
+
+        $this->assertEquals('another_string', (string) $mock);
+    }
 }


### PR DESCRIPTION
This PR improves on the modification done in commit https://github.com/sebastianbergmann/phpunit-mock-objects/commit/cf6796c93d3fa1bbd6aa62a5053a2f28f6d679f3 regarding a mock object `__toString` method.

The issue I was facing was: a mock had to return a specific string when its `__toString` method was invoked, but with the previous implementation it would always return an empty string.

The solution I implemented will check if the invocation is for `__toString` and return an empty string by default or the `$returnValue` value if it has been specified when creating the mock.