### PR TITLE
Fix mocking __toString() return value

### DIFF
--- a/src/Framework/MockObject/InvocationMocker.php
+++ b/src/Framework/MockObject/InvocationMocker.php
@@ -100,13 +100,7 @@ class PHPUnit_Framework_MockObject_InvocationMocker implements PHPUnit_Framework
     {
         $exception      = null;
         $hasReturnValue = false;
-
-        if (strtolower($invocation->methodName) == '__tostring') {
-            $hasReturnValue = true;
-            $returnValue    = '';
-        } else {
-            $returnValue = null;
-        }
+        $returnValue    = null;
 
         foreach ($this->matchers as $match) {
             try {
@@ -129,6 +123,8 @@ class PHPUnit_Framework_MockObject_InvocationMocker implements PHPUnit_Framework
 
         if ($hasReturnValue) {
             return $returnValue;
+        } elseif (strtolower($invocation->methodName) == '__tostring') {
+            return '';
         }
 
         return $invocation->generateReturnValue();

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -841,4 +841,12 @@ class Framework_MockObjectTest extends PHPUnit_Framework_TestCase
 
         $this->assertInternalType('string', (string) $mock);
     }
+
+    public function testStringableClassCanBeMocked()
+    {
+        $mock = $this->getMock('StringableClass');
+        $mock->method('__toString')->willReturn('foo');
+
+        $this->assertSame('foo', (string) $mock);
+    }
 }


### PR DESCRIPTION
This regression has been introduced in 3.0.1: mocking the return value of __toString is broken and always returns the empty string. Here is a fix and a test case.
Tagging a new release would be great as symfony's tests are currently broken because of this.