### PR TITLE
Allow to call static methods by not mocking them

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -125,13 +125,14 @@ class PHPUnit_Framework_MockObject_Generator
      * @param  bool                                          $cloneArguments
      * @param  bool                                          $callOriginalMethods
      * @param  object                                        $proxyTarget
+     * @param  bool                                          $mockStaticMethods
      * @return object
      * @throws InvalidArgumentException
      * @throws PHPUnit_Framework_Exception
      * @throws PHPUnit_Framework_MockObject_RuntimeException
      * @since  Method available since Release 1.0.0
      */
-    public function getMock($type, $methods = array(), array $arguments = array(), $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $cloneArguments = true, $callOriginalMethods = false, $proxyTarget = null)
+    public function getMock($type, $methods = array(), array $arguments = array(), $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $cloneArguments = true, $callOriginalMethods = false, $proxyTarget = null, $mockStaticMethods = true)
     {
         if (!is_array($type) && !is_string($type)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'array or string');
@@ -206,7 +207,8 @@ class PHPUnit_Framework_MockObject_Generator
             $callOriginalClone,
             $callAutoload,
             $cloneArguments,
-            $callOriginalMethods
+            $callOriginalMethods,
+            $mockStaticMethods
         );
 
         return $this->getObject(
@@ -304,12 +306,13 @@ class PHPUnit_Framework_MockObject_Generator
      * @param  bool   $callAutoload
      * @param  array  $mockedMethods
      * @param  bool   $cloneArguments
+     * @param  bool   $mockStaticMethods
      * @return object
      * @since  Method available since Release 1.0.0
      * @throws PHPUnit_Framework_MockObject_RuntimeException
      * @throws PHPUnit_Framework_Exception
      */
-    public function getMockForAbstractClass($originalClassName, array $arguments = array(), $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $mockedMethods = array(), $cloneArguments = true)
+    public function getMockForAbstractClass($originalClassName, array $arguments = array(), $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $mockedMethods = array(), $cloneArguments = true, $mockStaticMethods = true)
     {
         if (!is_string($originalClassName)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
@@ -342,7 +345,9 @@ class PHPUnit_Framework_MockObject_Generator
                 $callOriginalConstructor,
                 $callOriginalClone,
                 $callAutoload,
-                $cloneArguments
+                $cloneArguments,
+                null,
+                $mockStaticMethods
             );
         } else {
             throw new PHPUnit_Framework_MockObject_RuntimeException(
@@ -364,12 +369,13 @@ class PHPUnit_Framework_MockObject_Generator
      * @param  bool   $callAutoload
      * @param  array  $mockedMethods
      * @param  bool   $cloneArguments
+     * @param  bool   $mockStaticMethods
      * @return object
      * @since  Method available since Release 1.2.3
      * @throws PHPUnit_Framework_MockObject_RuntimeException
      * @throws PHPUnit_Framework_Exception
      */
-    public function getMockForTrait($traitName, array $arguments = array(), $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $mockedMethods = array(), $cloneArguments = true)
+    public function getMockForTrait($traitName, array $arguments = array(), $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $mockedMethods = array(), $cloneArguments = true, $mockStaticMethods = true)
     {
         if (!is_string($traitName)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
@@ -413,7 +419,7 @@ class PHPUnit_Framework_MockObject_Generator
             $className['className']
         );
 
-        return $this->getMockForAbstractClass($className['className'], $arguments, $mockClassName, $callOriginalConstructor, $callOriginalClone, $callAutoload, $mockedMethods, $cloneArguments);
+        return $this->getMockForAbstractClass($className['className'], $arguments, $mockClassName, $callOriginalConstructor, $callOriginalClone, $callAutoload, $mockedMethods, $cloneArguments, $mockStaticMethods);
     }
 
     /**
@@ -483,9 +489,10 @@ class PHPUnit_Framework_MockObject_Generator
      * @param  bool         $callAutoload
      * @param  bool         $cloneArguments
      * @param  bool         $callOriginalMethods
+     * @param  bool         $mockStaticMethods
      * @return array
      */
-    public function generate($type, array $methods = null, $mockClassName = '', $callOriginalClone = true, $callAutoload = true, $cloneArguments = true, $callOriginalMethods = false)
+    public function generate($type, array $methods = null, $mockClassName = '', $callOriginalClone = true, $callAutoload = true, $cloneArguments = true, $callOriginalMethods = false, $mockStaticMethods = true)
     {
         if (is_array($type)) {
             sort($type);
@@ -497,7 +504,8 @@ class PHPUnit_Framework_MockObject_Generator
                 serialize($methods) .
                 serialize($callOriginalClone) .
                 serialize($cloneArguments) .
-                serialize($callOriginalMethods)
+                serialize($callOriginalMethods) .
+                serialize($mockStaticMethods)
             );
 
             if (isset(self::$cache[$key])) {
@@ -512,7 +520,8 @@ class PHPUnit_Framework_MockObject_Generator
             $callOriginalClone,
             $callAutoload,
             $cloneArguments,
-            $callOriginalMethods
+            $callOriginalMethods,
+            $mockStaticMethods
         );
 
         if (isset($key)) {
@@ -618,10 +627,11 @@ class PHPUnit_Framework_MockObject_Generator
      * @param  bool                        $callAutoload
      * @param  bool                        $cloneArguments
      * @param  bool                        $callOriginalMethods
+     * @param  bool                        $mockStaticMethods
      * @return array
      * @throws PHPUnit_Framework_Exception
      */
-    protected function generateMock($type, $methods, $mockClassName, $callOriginalClone, $callAutoload, $cloneArguments, $callOriginalMethods)
+    protected function generateMock($type, $methods, $mockClassName, $callOriginalClone, $callAutoload, $cloneArguments, $callOriginalMethods, $mockStaticMethods = true)
     {
         $templateDir   = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Generator' .
                          DIRECTORY_SEPARATOR;
@@ -752,7 +762,7 @@ class PHPUnit_Framework_MockObject_Generator
                 try {
                     $method = $class->getMethod($methodName);
 
-                    if ($this->canMockMethod($method)) {
+                    if ($this->canMockMethod($method, $mockStaticMethods)) {
                         $mockedMethods .= $this->generateMockedMethodDefinitionFromExisting(
                             $templateDir,
                             $method,
@@ -981,14 +991,16 @@ class PHPUnit_Framework_MockObject_Generator
 
     /**
      * @param  ReflectionMethod $method
+     * @param  bool             $mockStaticMethods
      * @return bool
      */
-    protected function canMockMethod(ReflectionMethod $method)
+    protected function canMockMethod(ReflectionMethod $method, $mockStaticMethods = true)
     {
         if ($method->isConstructor() ||
             $method->isFinal() ||
             $method->isPrivate() ||
-            isset($this->blacklistedMethodNames[$method->getName()])) {
+            isset($this->blacklistedMethodNames[$method->getName()]) ||
+            ($method->isStatic() && !$mockStaticMethods)) {
             return false;
         }
 

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -71,6 +71,11 @@ class PHPUnit_Framework_MockObject_MockBuilder
     private $proxyTarget = null;
 
     /**
+     * @var bool
+     */
+    private $mockStaticMethods = true;
+
+    /**
      * @param PHPUnit_Framework_TestCase $testCase
      * @param array|string               $type
      */
@@ -97,7 +102,8 @@ class PHPUnit_Framework_MockObject_MockBuilder
             $this->autoload,
             $this->cloneArguments,
             $this->callOriginalMethods,
-            $this->proxyTarget
+            $this->proxyTarget,
+            $this->mockStaticMethods
         );
     }
 
@@ -116,7 +122,8 @@ class PHPUnit_Framework_MockObject_MockBuilder
             $this->originalClone,
             $this->autoload,
             $this->methods,
-            $this->cloneArguments
+            $this->cloneArguments,
+            $this->mockStaticMethods
         );
     }
 
@@ -135,7 +142,8 @@ class PHPUnit_Framework_MockObject_MockBuilder
             $this->originalClone,
             $this->autoload,
             $this->methods,
-            $this->cloneArguments
+            $this->cloneArguments,
+            $this->mockStaticMethods
         );
     }
 
@@ -316,6 +324,32 @@ class PHPUnit_Framework_MockObject_MockBuilder
     public function setProxyTarget($object)
     {
         $this->proxyTarget = $object;
+
+        return $this;
+    }
+
+    /**
+     * Enables the static method mocking (letting the mock calling the original static method).
+     *
+     * @return PHPUnit_Framework_MockObject_MockBuilder
+     * @since  Method available since Release 3.0.5
+     */
+    public function enableStaticMethods()
+    {
+        $this->mockStaticMethods = false;
+
+        return $this;
+    }
+
+    /**
+     * Disables the static method mocking (thow an exception when calling a mock static method).
+     *
+     * @return PHPUnit_Framework_MockObject_MockBuilder
+     * @since  Method available since Release 3.0.5
+     */
+    public function disableStaticMethods()
+    {
+        $this->mockStaticMethods = true;
 
         return $this;
     }

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -817,6 +817,33 @@ class Framework_MockObjectTest extends PHPUnit_Framework_TestCase
         $mock->staticMethod();
     }
 
+    public function testInvokingStubbedStaticMethodWithStaticMethodsMockingEnabled()
+    {
+        // This test should look like the following instead of calling directly the mock object generator
+        // but we first need to update the "phpunit/phpunit" package with the new "mockStaticMethods" parameter.
+        // Let's see if this addition is accepted.
+        //
+        // $mock = $this->getMockBuilder('ClassWithStaticMethod')
+        //     ->enableStaticMethods()
+        //     ->getMock();
+
+        $mock = $this->getMockObjectGenerator()->getMock(
+            'ClassWithStaticMethod',
+            array(),
+            array(),
+            '',
+            true,
+            true,
+            true,
+            true,
+            false,
+            null,
+            false
+        );
+
+        $this->assertSame('test', $mock->staticMethod());
+    }
+
     /**
      * @see    https://github.com/sebastianbergmann/phpunit-mock-objects/issues/171
      * @ticket 171

--- a/tests/_fixture/ClassWithStaticMethod.php
+++ b/tests/_fixture/ClassWithStaticMethod.php
@@ -3,5 +3,6 @@ class ClassWithStaticMethod
 {
     public static function staticMethod()
     {
+        return 'test';
     }
 }


### PR DESCRIPTION
Hey!

Let me explain my use case first: I would like to mock a Symfony2 event subscriber when it is used by the event dispatcher. Since the `EventSubscriberInterface::getSubscribedEvents` is static, I can't mock it.

In such case, you know that mocking a static method is not possible as nothing is interceptable but my point is not about mocking this method but the one called by the dispatcher. This one is not static and so is mockable but since the static method is called at the beginning of the event dispatcing, the mock becomes unusable (throw bad method exception) whereas allowing to call the original static method would be great.

Then, I would like to introduce a new parameter which allows static methods in a mock by simply not mocking them. Doing so, the generator will not generate these static methods and let the original method in place behing called.

This behavior is disabled by default and so if a developer enables it, it is aware these static methods are not mockable but if they are called, then, the default implementation will be called without possibility to intercept anything for then but you still can use the mocking system in such case :)

What do you think?