### PR TITLE
Disable constructor in auto-generated return mock

### DIFF
--- a/src/Framework/MockObject/Invocation/Static.php
+++ b/src/Framework/MockObject/Invocation/Static.php
@@ -135,7 +135,7 @@ class PHPUnit_Framework_MockObject_Invocation_Static implements PHPUnit_Framewor
             default:
                 $generator = new PHPUnit_Framework_MockObject_Generator;
 
-                return $generator->getMock($this->returnType);
+                return $generator->getMock($this->returnType, [], [], '', false);
         }
     }
 


### PR DESCRIPTION
If a function declares a concrete class that has a constructor with required arguments as a return type, auto-generating a mock object to return from the mocked function will fail. This simple fix disables calling the original constructor on the mocked object.