### PR TITLE
Allow throwing any Throwable

### DIFF
--- a/src/Framework/MockObject/Stub/Exception.php
+++ b/src/Framework/MockObject/Stub/Exception.php
@@ -19,8 +19,14 @@ class PHPUnit_Framework_MockObject_Stub_Exception implements PHPUnit_Framework_M
 {
     protected $exception;
 
-    public function __construct(Exception $exception)
+    public function __construct($exception)
     {
+        if (!$exception instanceof Throwable && !$exception instanceof Exception) {
+            throw new PHPUnit_Framework_Exception(
+                'Exception must be an instance of Throwable (PHP 7) or Exception (PHP 5)'
+            );
+        }
+
         $this->exception = $exception;
     }
 


### PR DESCRIPTION
Removed the `Exception` type declaration so an instance of Error can be passed in PHP 7. Will follow this up with a pull on PHPUnit to fix `TestCase::throwException()`.