### PR TITLE
Improve ReturnValueMap

### DIFF
--- a/src/Stub/ReturnValueMap.php
+++ b/src/Stub/ReturnValueMap.php
@@ -29,9 +29,9 @@ class PHPUnit_Framework_MockObject_Stub_ReturnValueMap implements PHPUnit_Framew
                 continue;
             }
 
-            $return = array_pop($map);
-            if ($invocation->parameters === $map) {
-                return $return;
+            $returnValue = $this->getReturnValue(array_pop($map));
+            if ($this->compare($invocation->parameters, $map)) {
+                return $returnValue->invoke($invocation);
             }
         }
 
@@ -41,5 +41,33 @@ class PHPUnit_Framework_MockObject_Stub_ReturnValueMap implements PHPUnit_Framew
     public function toString()
     {
         return 'return value from a map';
+    }
+
+    /**
+     * @param  array $actual
+     * @param  array $expected
+     * @return bool
+     */
+    protected function compare($actual, $expected) {
+        foreach ($expected as $index => $value) {
+            if ($value instanceof PHPUnit_Framework_Constraint) {
+                if ($value->evaluate($actual[$index], '', true) === false) {
+                    return false;
+                }
+            } else {
+                if ($value !== $actual[$index]) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    protected function getReturnValue($value) {
+      if (!$value instanceOf PHPUnit_Framework_MockObject_Stub) {
+        return new PHPUnit_Framework_MockObject_Stub_Return($value);
+      }
+      return $value;
     }
 }

--- a/tests/MockObject/Stub/ReturnValueMapTest.php
+++ b/tests/MockObject/Stub/ReturnValueMapTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\ExpectationFailedException;
+
+class ReturnValueMapTest extends TestCase
+{
+
+  /**
+  * @test
+  **/
+  public function returns_the_first_match_found()
+  {
+    $map = [
+        ['a', 'b', 'c', 'd'],
+        ['a', 'b', 'c', 'e'],
+        ['e', 'f', 'g', 'h']
+    ];
+
+    $mock = $this->getMockBuilder(AnInterface::class)
+                 ->getMock();
+
+    $mock->expects($this->any())
+         ->method('doSomething')
+         ->will($this->returnValueMap($map));
+
+    $this->assertEquals('d', $mock->doSomething('a', 'b', 'c'));
+  }
+
+  /**
+  * @test
+  **/
+  public function accepts_framework_matchers() {
+    $map = [
+        [$this->lessThan(2), 1],
+        [$this->greaterThanOrEqual(2), 2]
+    ];
+
+    $mock = $this->getMockBuilder(AnInterface::class)
+                 ->getMock();
+
+    $mock->expects($this->any())
+         ->method('doSomething')
+         ->will($this->returnValueMap($map));
+
+    $this->assertEquals(1, $mock->doSomething(0));
+    $this->assertEquals(2, $mock->doSomething(100));
+  }
+
+  /**
+  * @test
+  **/
+  public function accepts_stub_for_return_value() {
+    $callback = new PHPUnit_Framework_MockObject_Stub_ReturnCallback(
+        function($arg) { return $arg + 1; }
+    );
+
+    $map = [
+        [$this->lessThan(2), 1],
+        [$this->greaterThanOrEqual(2), $callback]
+    ];
+
+    $mock = $this->getMockBuilder(AnInterface::class)
+                 ->getMock();
+
+    $mock->expects($this->any())
+         ->method('doSomething')
+         ->will($this->returnValueMap($map));
+
+
+    $this->assertEquals(3, $mock->doSomething(2));
+  }
+
+  /**
+  * @test
+  **/
+  public function returns_null_if_no_match_found()
+  {
+      $map = [
+          ['a', 'b', 'c', 'd'],
+      ];
+
+      $mock = $this->getMockBuilder(AnInterface::class)
+                   ->getMock();
+
+      $mock->expects($this->any())
+           ->method('doSomething')
+           ->will($this->returnValueMap($map));
+
+      $this->assertEquals(null, $mock->doSomething('foo', 'bar'));
+  }
+}

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -212,36 +212,6 @@ class Framework_MockObjectTest extends TestCase
         $this->assertEquals('something', $mock->doSomething());
     }
 
-    public function testStubbedReturnValueMap()
-    {
-        $map = [
-            ['a', 'b', 'c', 'd'],
-            ['e', 'f', 'g', 'h']
-        ];
-
-        $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
-
-        $mock->expects($this->any())
-             ->method('doSomething')
-             ->will($this->returnValueMap($map));
-
-        $this->assertEquals('d', $mock->doSomething('a', 'b', 'c'));
-        $this->assertEquals('h', $mock->doSomething('e', 'f', 'g'));
-        $this->assertEquals(null, $mock->doSomething('foo', 'bar'));
-
-        $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
-
-        $mock->expects($this->any())
-             ->method('doSomething')
-             ->willReturnMap($map);
-
-        $this->assertEquals('d', $mock->doSomething('a', 'b', 'c'));
-        $this->assertEquals('h', $mock->doSomething('e', 'f', 'g'));
-        $this->assertEquals(null, $mock->doSomething('foo', 'bar'));
-    }
-
     public function testStubbedReturnArgument()
     {
         $mock = $this->getMockBuilder(AnInterface::class)


### PR DESCRIPTION
One thing that ReturnValueMap lacks is flexibility regarding the arguments the method was invoked with. It works only with exact match. As a side effect, if you have floats as arguments, it may fail. As a solution, I've added support for Framework_Constraint objects.

Another one is that the return value is just a simple value. So I've added the option to use Framework_Stub objects, such as ReturnCallback
