### PR TITLE
Type hint \PHPUnit_Framework_MockObject_MockBuilder::setMethods()

### DIFF
--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -145,7 +145,7 @@ class PHPUnit_Framework_MockObject_MockBuilder
      * @param  array|null                               $methods
      * @return PHPUnit_Framework_MockObject_MockBuilder
      */
-    public function setMethods($methods)
+    public function setMethods(array $methods = null)
     {
         $this->methods = $methods;
 


### PR DESCRIPTION
Any reason not to do this? It's a little thing, but I feel like it would improve the developer experience.