### PR TITLE
Add ReturnAllArguments stub

### DIFF
--- a/src/Framework/MockObject/Builder/InvocationMocker.php
+++ b/src/Framework/MockObject/Builder/InvocationMocker.php
@@ -117,6 +117,15 @@ class PHPUnit_Framework_MockObject_Builder_InvocationMocker implements PHPUnit_F
     }
 
     /**
+     * @return PHPUnit_Framework_MockObject_Builder_InvocationMocker
+     */
+    public function willReturnAllArguments()
+    {
+        $stub = new PHPUnit_Framework_MockObject_Stub_ReturnAllArguments(null);
+        return $this->will($stub);
+    }
+
+    /**
      * @param  callable                                              $callback
      * @return PHPUnit_Framework_MockObject_Builder_InvocationMocker
      */

--- a/src/Framework/MockObject/Stub/ReturnAllArguments.php
+++ b/src/Framework/MockObject/Stub/ReturnAllArguments.php
@@ -1,0 +1,28 @@
+<?php
+class PHPUnit_Framework_MockObject_Stub_ReturnAllArguments extends PHPUnit_Framework_MockObject_Stub_Return
+{
+    /**
+     * @param PHPUnit_Framework_MockObject_Invocation $invocation
+     * @return mixed
+     *
+     * @author Luke Rodgers <lukerodgers90@gmail.com>
+     */
+    public function invoke(PHPUnit_Framework_MockObject_Invocation $invocation)
+    {
+        if (isset($invocation->parameters)) {
+            return $invocation->parameters;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * @return string
+     *
+     * @author Luke Rodgers <lukerodgers90@gmail.com>
+     */
+    public function toString()
+    {
+        return sprintf('return all arguments');
+    }
+}

--- a/tests/MockObject/Stub/ReturnAllArgumentsTest.php
+++ b/tests/MockObject/Stub/ReturnAllArgumentsTest.php
@@ -1,0 +1,19 @@
+<?php
+
+class ReturnAllArgumentsTest extends PHPUnit_Framework_TestCase
+{
+    public function testStubbedReturnArguments()
+    {
+        $mock = $this->getMock('AnInterface');
+        $mock->expects($this->any())
+            ->method('doSomething')
+            ->willReturnAllArguments();
+        $this->assertEquals(array('a', 'b', 'c'), $mock->doSomething('a', 'b', 'c'));
+
+        $mock = $this->getMock('AnInterface');
+        $mock->expects($this->any())
+            ->method('doSomething')
+            ->willReturnAllArguments();
+        $this->assertEquals(array('1', '5', '9'), $mock->doSomething('1', '5', '9'));
+    }
+}


### PR DESCRIPTION
Another attempt at #248

Add a stub to return all the arguments passed into a function.

```
$mock = $this->getMock('AnInterface');
$mock->expects($this->any())
            ->method('doSomething')
            ->willReturnAllArguments();
$this->assertEquals(array('a', 'b', 'c'), $mock->doSomething('a', 'b', 'c'));
```
