### PR TITLE
ReturnReference stub

### DIFF
--- a/src/Framework/MockObject/Builder/InvocationMocker.php
+++ b/src/Framework/MockObject/Builder/InvocationMocker.php
@@ -102,6 +102,17 @@ class PHPUnit_Framework_MockObject_Builder_InvocationMocker implements PHPUnit_F
     }
 
     /**
+     * @param  mixed                                                 $reference
+     * @return PHPUnit_Framework_MockObject_Builder_InvocationMocker
+     */
+    public function willReturnReference(&$reference)
+    {
+        $stub = new PHPUnit_Framework_MockObject_Stub_ReturnReference($reference);
+
+        return $this->will($stub);
+    }
+
+    /**
      * @param array $valueMap
      *
      * @return PHPUnit_Framework_MockObject_Builder_InvocationMocker

--- a/src/Framework/MockObject/Stub/ReturnReference.php
+++ b/src/Framework/MockObject/Stub/ReturnReference.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * This file is part of the PHPUnit_MockObject package.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Stubs a method by returning a user-defined reference to a value.
+ *
+ * @since Class available since Release 3.0.7
+ */
+class PHPUnit_Framework_MockObject_Stub_ReturnReference extends PHPUnit_Framework_MockObject_Stub_Return
+{
+    public function __construct(&$value)
+    {
+        $this->value = &$value;
+    }
+}

--- a/tests/MockObject/Builder/InvocationMockerTest.php
+++ b/tests/MockObject/Builder/InvocationMockerTest.php
@@ -43,4 +43,19 @@ class Framework_MockObject_Builder_InvocationMockerTest extends PHPUnit_Framewor
         $this->assertEquals(2, $mock->foo());
         $this->assertEquals(3, $mock->foo());
     }
+
+    public function testWillReturnByReference()
+    {
+        $mock = $this->getMock('stdClass', ['foo']);
+        $mock
+            ->expects($this->any())
+            ->method('foo')
+            ->willReturnReference($value);
+
+        $this->assertSame(null, $mock->foo());
+        $value = 'foo';
+        $this->assertSame('foo', $mock->foo());
+        $value = 'bar';
+        $this->assertSame('bar', $mock->foo());
+    }
 }


### PR DESCRIPTION
A widely used pattern is to setup a mock object in the `setUp` method and allow replacing return values during runtime. Right now one needs to use `willReturnCallback()`. The following example illustrates the problem:
```php
public function setUp()
{
    $this->user = …;
    $this->userProvider = $this->getMock(…);
    $this->userProvider
       ->expects($this->any())
       ->method('getUser')
       ->willReturnCallback(function() {return $this->user;});
}

public function testSomething()
{
    $this->user = $this->someOtherUser;
    // Do something
}
```

This PR adds `willReturnReference()` that allows us to refactor `setUp()` to be cleaner and look like this:
```php
public function setUp()
{
    $this->user = …;
    $this->userProvider = $this->getMock(…);
    $this->userProvider
       ->expects($this->any())
       ->method('getUser')
       ->willReturnReference($this->user);
}
```