### PR TITLE
Improved exception message in case of duplicate method names

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -191,8 +191,9 @@ class PHPUnit_Framework_MockObject_Generator
             if ($methods != array_unique($methods)) {
                 throw new PHPUnit_Framework_MockObject_RuntimeException(
                     sprintf(
-                        'Cannot stub or mock using a method list that contains duplicates: "%s"',
-                        implode(', ', $methods)
+                        'Cannot stub or mock using a method list that contains duplicates: "%s" (duplicate: "%s")',
+                        implode(', ', $methods),
+                        implode(', ', array_unique(array_diff_assoc($methods, array_unique($methods))))
                     )
                 );
             }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -33,11 +33,11 @@ class Framework_MockObject_GeneratorTest extends PHPUnit_Framework_TestCase
     /**
      * @covers PHPUnit_Framework_MockObject_Generator::getMock
      * @expectedException PHPUnit_Framework_MockObject_RuntimeException
-     * @expectedExceptionMessage duplicates: "foo, foo"
+     * @expectedExceptionMessage duplicates: "foo, bar, foo" (duplicate: "foo")
      */
     public function testGetMockGeneratorFails()
     {
-        $this->generator->getMock(StdClass::class, ['foo', 'foo']);
+        $this->generator->getMock(StdClass::class, ['foo', 'bar', 'foo']);
     }
 
     /**


### PR DESCRIPTION
I just changed the exception message in case duplicate method names are passed into the mock builder by adding the duplicate method name(s).

**Example:**
```$this->getMock(Redis::class,` ["hget", "incr", "hgetall", "hmset", "hset", "hdel", "hget"]);```

Changed:
> Cannot stub or mock using a method list that contains duplicates: "hget, incr, hgetall, hmset, hset, hdel, hget"

to:

> Cannot stub or mock using a method list that contains duplicates: "hget, incr, hgetall, hmset, hset, hdel, hget" **(duplicate:"hget")**
