### PR TITLE
clarify unconfigurable method message a bit more

### DIFF
--- a/src/Framework/MockObject/Builder/InvocationMocker.php
+++ b/src/Framework/MockObject/Builder/InvocationMocker.php
@@ -271,7 +271,7 @@ class PHPUnit_Framework_MockObject_Builder_InvocationMocker implements PHPUnit_F
         if (is_string($constraint) && !in_array(strtolower($constraint), $this->configurableMethods)) {
             throw new PHPUnit_Framework_MockObject_RuntimeException(
                 sprintf(
-                    'Trying to configure method "%s" which cannot be configured because it does not exist, is final, or is static',
+                    'Trying to configure method "%s" which cannot be configured because it does not exist, is final, or is static or it was not configured to be mocked',
                     $constraint
                 )
             );


### PR DESCRIPTION
When looking at the list of failures from the Symfony test suite from https://github.com/sebastianbergmann/phpunit-mock-objects/issues/299#issuecomment-200443756, I noticed that there is one other reason why the `InvocationMocker` can complain about a method that cannot be configured:

```php
$container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder', array(
    'getExtensionConfig',
    'loadFromExtension',
    'getParameterBag',
));
$container->expects($this->any())
    ->method('getDefinitions')
    ->will($this->returnValue(array()));
```

The reason is that the method that should be configured (`getDefinitions()` in this case) was not included in the list of methods passed to `getMock()`.