### PR TITLE
Add the ability for mock builder to create stubs for all methods EXCE…

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -234,7 +234,7 @@ class PHPUnit_Framework_MockObject_Generator
             }
         }
 
-        if (null !== $methods && null !== $notMethods)
+        if (!empty($methods) && !empty($notMethods))
         {
             throw new PHPUnit_Framework_MockObject_RuntimeException(
                 'Cannot build mockobject that sets stub methods (setMethods) and exempts stub methods (setNotMethods) at the same time.'

--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -234,6 +234,13 @@ class PHPUnit_Framework_MockObject_Generator
             }
         }
 
+        if (null !== $methods && null !== $notMethods)
+        {
+            throw new PHPUnit_Framework_MockObject_RuntimeException(
+                'Cannot build mockobject that sets stub methods (setMethods) and exempts stub methods (setNotMethods) at the same time.'
+            );
+        }
+
         if ($mockClassName != '' && class_exists($mockClassName, false)) {
             $reflect = new ReflectionClass($mockClassName);
 

--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -135,7 +135,6 @@ class PHPUnit_Framework_MockObject_Generator
      * @param bool         $callOriginalMethods
      * @param object       $proxyTarget
      * @param bool         $allowMockingUnknownTypes
-     * @param array        $notMethods
      *
      * @return PHPUnit_Framework_MockObject_MockObject
      *
@@ -145,7 +144,7 @@ class PHPUnit_Framework_MockObject_Generator
      *
      * @since  Method available since Release 1.0.0
      */
-    public function getMock($type, $methods = [], array $arguments = [], $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $cloneArguments = true, $callOriginalMethods = false, $proxyTarget = null, $allowMockingUnknownTypes = true, $notMethods = [])
+    public function getMock($type, $methods = [], array $arguments = [], $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $cloneArguments = true, $callOriginalMethods = false, $proxyTarget = null, $allowMockingUnknownTypes = true)
     {
         if (!is_array($type) && !is_string($type)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'array or string');
@@ -157,10 +156,6 @@ class PHPUnit_Framework_MockObject_Generator
 
         if (!is_array($methods) && !is_null($methods)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'array', $methods);
-        }
-
-        if (!is_array($notMethods) && !is_null($notMethods)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(12, 'array', $notMethods);
         }
 
         if ($type === 'Traversable' || $type === '\\Traversable') {
@@ -234,13 +229,6 @@ class PHPUnit_Framework_MockObject_Generator
             }
         }
 
-        if (!empty($methods) && !empty($notMethods))
-        {
-            throw new PHPUnit_Framework_MockObject_RuntimeException(
-                'Cannot build mockobject that sets stub methods (setMethods) and exempts stub methods (setNotMethods) at the same time.'
-            );
-        }
-
         if ($mockClassName != '' && class_exists($mockClassName, false)) {
             $reflect = new ReflectionClass($mockClassName);
 
@@ -267,8 +255,7 @@ class PHPUnit_Framework_MockObject_Generator
             $callOriginalClone,
             $callAutoload,
             $cloneArguments,
-            $callOriginalMethods,
-            $notMethods
+            $callOriginalMethods
         );
 
         return $this->getObject(
@@ -367,7 +354,6 @@ class PHPUnit_Framework_MockObject_Generator
      * @param bool   $callAutoload
      * @param array  $mockedMethods
      * @param bool   $cloneArguments
-     * @param array  $notMockedMethods
      *
      * @return PHPUnit_Framework_MockObject_MockObject
      *
@@ -376,7 +362,7 @@ class PHPUnit_Framework_MockObject_Generator
      * @throws PHPUnit_Framework_MockObject_RuntimeException
      * @throws PHPUnit_Framework_Exception
      */
-    public function getMockForAbstractClass($originalClassName, array $arguments = [], $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $mockedMethods = [], $cloneArguments = true, $notMockedMethods = [])
+    public function getMockForAbstractClass($originalClassName, array $arguments = [], $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $mockedMethods = [], $cloneArguments = true)
     {
         if (!is_string($originalClassName)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
@@ -409,11 +395,7 @@ class PHPUnit_Framework_MockObject_Generator
                 $callOriginalConstructor,
                 $callOriginalClone,
                 $callAutoload,
-                $cloneArguments,
-                false,
-                null,
-                true,
-                $notMockedMethods
+                $cloneArguments
             );
         } else {
             throw new PHPUnit_Framework_MockObject_RuntimeException(
@@ -435,7 +417,6 @@ class PHPUnit_Framework_MockObject_Generator
      * @param bool   $callAutoload
      * @param array  $mockedMethods
      * @param bool   $cloneArguments
-     * @param array  $notMockedMethods
      *
      * @return PHPUnit_Framework_MockObject_MockObject
      *
@@ -444,7 +425,7 @@ class PHPUnit_Framework_MockObject_Generator
      * @throws PHPUnit_Framework_MockObject_RuntimeException
      * @throws PHPUnit_Framework_Exception
      */
-    public function getMockForTrait($traitName, array $arguments = [], $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $mockedMethods = [], $cloneArguments = true, $notMockedMethods = [])
+    public function getMockForTrait($traitName, array $arguments = [], $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $mockedMethods = [], $cloneArguments = true)
     {
         if (!is_string($traitName)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
@@ -488,7 +469,7 @@ class PHPUnit_Framework_MockObject_Generator
             $className['className']
         );
 
-        return $this->getMockForAbstractClass($className['className'], $arguments, $mockClassName, $callOriginalConstructor, $callOriginalClone, $callAutoload, $mockedMethods, $cloneArguments, $notMockedMethods);
+        return $this->getMockForAbstractClass($className['className'], $arguments, $mockClassName, $callOriginalConstructor, $callOriginalClone, $callAutoload, $mockedMethods, $cloneArguments);
     }
 
     /**
@@ -561,11 +542,10 @@ class PHPUnit_Framework_MockObject_Generator
      * @param bool         $callAutoload
      * @param bool         $cloneArguments
      * @param bool         $callOriginalMethods
-     * @param array        $notMethods
      *
      * @return array
      */
-    public function generate($type, array $methods = null, $mockClassName = '', $callOriginalClone = true, $callAutoload = true, $cloneArguments = true, $callOriginalMethods = false, $notMethods = null)
+    public function generate($type, array $methods = null, $mockClassName = '', $callOriginalClone = true, $callAutoload = true, $cloneArguments = true, $callOriginalMethods = false)
     {
         if (is_array($type)) {
             sort($type);
@@ -575,7 +555,6 @@ class PHPUnit_Framework_MockObject_Generator
             $key = md5(
                 is_array($type) ? implode('_', $type) : $type .
                 serialize($methods) .
-				serialize($notMethods) .
                 serialize($callOriginalClone) .
                 serialize($cloneArguments) .
                 serialize($callOriginalMethods)
@@ -593,8 +572,7 @@ class PHPUnit_Framework_MockObject_Generator
             $callOriginalClone,
             $callAutoload,
             $cloneArguments,
-            $callOriginalMethods,
-            $notMethods
+            $callOriginalMethods
         );
 
         if (isset($key)) {
@@ -702,13 +680,12 @@ class PHPUnit_Framework_MockObject_Generator
      * @param bool         $callAutoload
      * @param bool         $cloneArguments
      * @param bool         $callOriginalMethods
-     * @param array|null   $notMethods
      *
      * @return array
      *
      * @throws PHPUnit_Framework_MockObject_RuntimeException
      */
-    private function generateMock($type, $methods, $mockClassName, $callOriginalClone, $callAutoload, $cloneArguments, $callOriginalMethods, $notMethods)
+    private function generateMock($type, $methods, $mockClassName, $callOriginalClone, $callAutoload, $cloneArguments, $callOriginalMethods)
     {
         $templateDir   = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Generator' .
                          DIRECTORY_SEPARATOR;
@@ -815,10 +792,6 @@ class PHPUnit_Framework_MockObject_Generator
         if (is_array($methods) && empty($methods) &&
             ($isClass || $isInterface)) {
             $methods = $this->getClassMethods($mockClassName['fullClassName']);
-
-            if (is_array($notMethods) && !empty($notMethods)) {
-                $methods = array_diff($methods, $notMethods);
-            }
         }
 
         if (!is_array($methods)) {

--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -1235,7 +1235,7 @@ class PHPUnit_Framework_MockObject_Generator
      *
      * @since  Method available since Release 2.3.2
      */
-    private function getClassMethods($className)
+    public function getClassMethods($className)
     {
         $class   = new ReflectionClass($className);
         $methods = [];

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -31,6 +31,11 @@ class PHPUnit_Framework_MockObject_MockBuilder
     private $methods = [];
 
     /**
+     * @var array
+     */
+    private $notMethods = [];
+
+    /**
      * @var string
      */
     private $mockClassName = '';
@@ -105,7 +110,8 @@ class PHPUnit_Framework_MockObject_MockBuilder
             $this->cloneArguments,
             $this->callOriginalMethods,
             $this->proxyTarget,
-            $this->allowMockingUnknownTypes
+            $this->allowMockingUnknownTypes,
+            $this->notMethods
         );
 
         $this->testCase->registerMockObject($object);
@@ -130,7 +136,8 @@ class PHPUnit_Framework_MockObject_MockBuilder
             $this->originalClone,
             $this->autoload,
             $this->methods,
-            $this->cloneArguments
+            $this->cloneArguments,
+            $this->notMethods
         );
 
         $this->testCase->registerMockObject($object);
@@ -155,7 +162,8 @@ class PHPUnit_Framework_MockObject_MockBuilder
             $this->originalClone,
             $this->autoload,
             $this->methods,
-            $this->cloneArguments
+            $this->cloneArguments,
+            $this->notMethods
         );
 
         $this->testCase->registerMockObject($object);
@@ -173,6 +181,20 @@ class PHPUnit_Framework_MockObject_MockBuilder
     public function setMethods($methods)
     {
         $this->methods = $methods;
+
+        return $this;
+    }
+
+    /**
+     * Specifies methods to not mock. Default is to mock everything.
+     *
+     * @param array|null $methods
+     *
+     * @return PHPUnit_Framework_MockObject_MockBuilder
+     */
+    public function setNotMethods($methods)
+    {
+        $this->notMethods = $methods;
 
         return $this;
     }

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -31,11 +31,6 @@ class PHPUnit_Framework_MockObject_MockBuilder
     private $methods = [];
 
     /**
-     * @var array
-     */
-    private $notMethods = [];
-
-    /**
      * @var string
      */
     private $mockClassName = '';
@@ -110,8 +105,7 @@ class PHPUnit_Framework_MockObject_MockBuilder
             $this->cloneArguments,
             $this->callOriginalMethods,
             $this->proxyTarget,
-            $this->allowMockingUnknownTypes,
-            $this->notMethods
+            $this->allowMockingUnknownTypes
         );
 
         $this->testCase->registerMockObject($object);
@@ -136,8 +130,7 @@ class PHPUnit_Framework_MockObject_MockBuilder
             $this->originalClone,
             $this->autoload,
             $this->methods,
-            $this->cloneArguments,
-            $this->notMethods
+            $this->cloneArguments
         );
 
         $this->testCase->registerMockObject($object);
@@ -162,8 +155,7 @@ class PHPUnit_Framework_MockObject_MockBuilder
             $this->originalClone,
             $this->autoload,
             $this->methods,
-            $this->cloneArguments,
-            $this->notMethods
+            $this->cloneArguments
         );
 
         $this->testCase->registerMockObject($object);
@@ -181,20 +173,6 @@ class PHPUnit_Framework_MockObject_MockBuilder
     public function setMethods($methods)
     {
         $this->methods = $methods;
-
-        return $this;
-    }
-
-    /**
-     * Specifies methods to not mock. Default is to mock everything.
-     *
-     * @param array|null $methods
-     *
-     * @return PHPUnit_Framework_MockObject_MockBuilder
-     */
-    public function setNotMethods($methods)
-    {
-        $this->notMethods = $methods;
 
         return $this;
     }

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -31,6 +31,11 @@ class PHPUnit_Framework_MockObject_MockBuilder
     private $methods = [];
 
     /**
+     * @var array
+     */
+    private $methodsExcept = [];
+
+    /**
      * @var string
      */
     private $mockClassName = '';
@@ -76,13 +81,19 @@ class PHPUnit_Framework_MockObject_MockBuilder
     private $allowMockingUnknownTypes = true;
 
     /**
+     * @var PHPUnit_Framework_MockObject_Generator
+     */
+    private $generator;
+
+    /**
      * @param PHPUnit_Framework_TestCase $testCase
      * @param array|string               $type
      */
     public function __construct(PHPUnit_Framework_TestCase $testCase, $type)
     {
-        $this->testCase = $testCase;
-        $this->type     = $type;
+        $this->testCase  = $testCase;
+        $this->type      = $type;
+        $this->generator = new PHPUnit_Framework_MockObject_Generator;
     }
 
     /**
@@ -92,9 +103,7 @@ class PHPUnit_Framework_MockObject_MockBuilder
      */
     public function getMock()
     {
-        $generator = new PHPUnit_Framework_MockObject_Generator;
-
-        $object = $generator->getMock(
+        $object = $this->generator->getMock(
             $this->type,
             $this->methods,
             $this->constructorArgs,
@@ -120,9 +129,7 @@ class PHPUnit_Framework_MockObject_MockBuilder
      */
     public function getMockForAbstractClass()
     {
-        $generator = new PHPUnit_Framework_MockObject_Generator;
-
-        $object = $generator->getMockForAbstractClass(
+        $object = $this->generator->getMockForAbstractClass(
             $this->type,
             $this->constructorArgs,
             $this->mockClassName,
@@ -145,9 +152,7 @@ class PHPUnit_Framework_MockObject_MockBuilder
      */
     public function getMockForTrait()
     {
-        $generator = new PHPUnit_Framework_MockObject_Generator;
-
-        $object = $generator->getMockForTrait(
+        $object = $this->generator->getMockForTrait(
             $this->type,
             $this->constructorArgs,
             $this->mockClassName,
@@ -173,6 +178,22 @@ class PHPUnit_Framework_MockObject_MockBuilder
     public function setMethods($methods)
     {
         $this->methods = $methods;
+
+        return $this;
+    }
+
+    /**
+     * Specifies the subset of methods to not mock. Default is to mock all of them.
+     *
+     * @param array $methods
+     *
+     * @return PHPUnit_Framework_MockObject_MockBuilder
+     */
+    public function setMethodsExcept(Array $methods = [])
+    {
+        $this->methodsExcept = $methods;
+
+        $this->setMethods(array_diff($this->generator->getClassMethods($this->type), $this->methodsExcept));
 
         return $this;
     }

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -177,6 +177,16 @@ class PHPUnit_Framework_MockObject_MockBuilder
      */
     public function setMethods($methods)
     {
+        if ($this->methods !== []) {
+            throw new PHPUnit_Framework_MockObject_RuntimeException(
+                sprintf(
+                    'Cannot call method "%s" after methods have already been set. Methods are: %s',
+                    __FUNCTION__,
+                    json_encode($this->methods)
+                )
+            );
+        }
+
         $this->methods = $methods;
 
         return $this;
@@ -191,6 +201,16 @@ class PHPUnit_Framework_MockObject_MockBuilder
      */
     public function setMethodsExcept(Array $methods = [])
     {
+        if ($this->methods !== []) {
+           throw new PHPUnit_Framework_MockObject_RuntimeException(
+               sprintf(
+                   'Cannot call method "%s" after methods have already been set. Methods are: %s',
+                   __FUNCTION__,
+                   json_encode($this->methods)
+               )
+           );
+        }
+
         $this->methodsExcept = $methods;
 
         $this->setMethods(array_diff($this->generator->getClassMethods($this->type), $this->methodsExcept));

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -177,16 +177,6 @@ class PHPUnit_Framework_MockObject_MockBuilder
      */
     public function setMethods($methods)
     {
-        if ($this->methods !== []) {
-            throw new PHPUnit_Framework_MockObject_RuntimeException(
-                sprintf(
-                    'Cannot call method "%s" after methods have already been set. Methods are: %s',
-                    __FUNCTION__,
-                    json_encode($this->methods)
-                )
-            );
-        }
-
         $this->methods = $methods;
 
         return $this;
@@ -201,16 +191,6 @@ class PHPUnit_Framework_MockObject_MockBuilder
      */
     public function setMethodsExcept(Array $methods = [])
     {
-        if ($this->methods !== []) {
-           throw new PHPUnit_Framework_MockObject_RuntimeException(
-               sprintf(
-                   'Cannot call method "%s" after methods have already been set. Methods are: %s',
-                   __FUNCTION__,
-                   json_encode($this->methods)
-               )
-           );
-        }
-
         $this->methodsExcept = $methods;
 
         $this->setMethods(array_diff($this->generator->getClassMethods($this->type), $this->methodsExcept));

--- a/tests/MockBuilderTest.php
+++ b/tests/MockBuilderTest.php
@@ -35,6 +35,16 @@ class Framework_MockBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($mock->anotherMockableMethod());
     }
 
+    public function testNotMethodsToMockCanBeSpecified()
+    {
+        $mock = $this->getMockBuilder(Mockable::class)
+            ->setNotMethods(['mockableMethod'])
+            ->getMock();
+
+        $this->assertTrue($mock->mockableMethod());
+        $this->assertNull($mock->anotherMockableMethod());
+    }
+
     public function testByDefaultDoesNotPassArgumentsToTheConstructor()
     {
         $mock = $this->getMockBuilder(Mockable::class)->getMock();

--- a/tests/MockBuilderTest.php
+++ b/tests/MockBuilderTest.php
@@ -35,6 +35,26 @@ class Framework_MockBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($mock->anotherMockableMethod());
     }
 
+    public function testMethodExceptionsToMockCanBeSpecified()
+    {
+        $mock = $this->getMockBuilder(Mockable::class)
+            ->setMethodsExcept(['mockableMethod'])
+            ->getMock();
+
+        $this->assertTrue($mock->mockableMethod());
+        $this->assertNull($mock->anotherMockableMethod());
+    }
+
+    public function testEmptyMethodExceptionsToMockCanBeSpecified()
+    {
+        $mock = $this->getMockBuilder(Mockable::class)
+            ->setMethodsExcept()
+            ->getMock();
+
+        $this->assertNull($mock->mockableMethod());
+        $this->assertNull($mock->anotherMockableMethod());
+    }
+
     public function testByDefaultDoesNotPassArgumentsToTheConstructor()
     {
         $mock = $this->getMockBuilder(Mockable::class)->getMock();

--- a/tests/MockBuilderTest.php
+++ b/tests/MockBuilderTest.php
@@ -55,6 +55,36 @@ class Framework_MockBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertNull($mock->anotherMockableMethod());
     }
 
+    /**
+     * @expectedException PHPUnit_Framework_MockObject_RuntimeException
+     * @expectedExceptionMessage Cannot call method "setMethodsExcept" after methods have already been set. Methods are: ["mockableMethod"]
+     */
+    public function testMethodsExceptAfterMethods()
+    {
+        $mock = $this->getMockBuilder(Mockable::class)
+            ->setMethods(['mockableMethod'])
+            ->setMethodsExcept(['anotherMockableMethod'])
+            ->getMock();
+
+        $this->assertNull($mock->mockableMethod());
+        $this->assertNull($mock->anotherMockableMethod());
+    }
+
+    /**
+     * @expectedException PHPUnit_Framework_MockObject_RuntimeException
+     * @expectedExceptionMessage Cannot call method "setMethods" after methods have already been set. Methods are: {"0":"__construct","1":"mockableMethod","3":"__clone"}
+     */
+    public function testMethodsAfterMethodsExcept()
+    {
+        $mock = $this->getMockBuilder(Mockable::class)
+            ->setMethodsExcept(['anotherMockableMethod'])
+            ->setMethods(['mockableMethod'])
+            ->getMock();
+
+        $this->assertNull($mock->mockableMethod());
+        $this->assertNull($mock->anotherMockableMethod());
+    }
+
     public function testByDefaultDoesNotPassArgumentsToTheConstructor()
     {
         $mock = $this->getMockBuilder(Mockable::class)->getMock();

--- a/tests/MockBuilderTest.php
+++ b/tests/MockBuilderTest.php
@@ -55,36 +55,6 @@ class Framework_MockBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertNull($mock->anotherMockableMethod());
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_MockObject_RuntimeException
-     * @expectedExceptionMessage Cannot call method "setMethodsExcept" after methods have already been set. Methods are: ["mockableMethod"]
-     */
-    public function testMethodsExceptAfterMethods()
-    {
-        $mock = $this->getMockBuilder(Mockable::class)
-            ->setMethods(['mockableMethod'])
-            ->setMethodsExcept(['anotherMockableMethod'])
-            ->getMock();
-
-        $this->assertNull($mock->mockableMethod());
-        $this->assertNull($mock->anotherMockableMethod());
-    }
-
-    /**
-     * @expectedException PHPUnit_Framework_MockObject_RuntimeException
-     * @expectedExceptionMessage Cannot call method "setMethods" after methods have already been set. Methods are: {"0":"__construct","1":"mockableMethod","3":"__clone"}
-     */
-    public function testMethodsAfterMethodsExcept()
-    {
-        $mock = $this->getMockBuilder(Mockable::class)
-            ->setMethodsExcept(['anotherMockableMethod'])
-            ->setMethods(['mockableMethod'])
-            ->getMock();
-
-        $this->assertNull($mock->mockableMethod());
-        $this->assertNull($mock->anotherMockableMethod());
-    }
-
     public function testByDefaultDoesNotPassArgumentsToTheConstructor()
     {
         $mock = $this->getMockBuilder(Mockable::class)->getMock();

--- a/tests/MockBuilderTest.php
+++ b/tests/MockBuilderTest.php
@@ -35,16 +35,6 @@ class Framework_MockBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($mock->anotherMockableMethod());
     }
 
-    public function testNotMethodsToMockCanBeSpecified()
-    {
-        $mock = $this->getMockBuilder(Mockable::class)
-            ->setNotMethods(['mockableMethod'])
-            ->getMock();
-
-        $this->assertTrue($mock->mockableMethod());
-        $this->assertNull($mock->anotherMockableMethod());
-    }
-
     public function testByDefaultDoesNotPassArgumentsToTheConstructor()
     {
         $mock = $this->getMockBuilder(Mockable::class)->getMock();


### PR DESCRIPTION
Functionality exists to add methods to mockbuilder that you want to mock via addMethods(). However, what if there is one or two methods that you want to exempt while leaving all the others? Without a method that works inverse to addMethods you would have to list all the methods via reflection and then remove the ones you wanted to leave as their original construct. This is helpful if you for example have setters that simply set a property on the object that future private/protected methods rely on.

The addNotMethods() function works inverse to addMethod() in that all methods are stubbed EXCEPT those provided in addNotMethods().