### PR TITLE
Add test broken method mock

### DIFF
--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -196,7 +196,7 @@ class Framework_MockObject_GeneratorTest extends PHPUnit_Framework_TestCase
      *
      * @ticket https://github.com/sebastianbergmann/phpunit-mock-objects/issues/322
      */
-    public function testCanConfigureMethodsForDoubleOfNonExistantClass()
+    public function testCanConfigureMethodsForDoubleOfNonExistentClass()
     {
         $className = 'X' . md5(microtime());
 

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -204,4 +204,18 @@ class Framework_MockObject_GeneratorTest extends PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf($className, $mock);
     }
+
+    /**
+     * @covers PHPUnit_Framework_MockObject_Generator::getMock
+     */
+    public function testCanInvokeMethodsOfNonExistentClass()
+    {
+        $className = 'X' . md5(microtime());
+
+        $mock = $this->generator->getMock($className, ['someMethod']);
+
+        $mock->expects($this->once())->method('someMethod');
+
+        $mock->someMethod();
+    }
 }


### PR DESCRIPTION
Added test to expose error when a configured method of a non existent class is invoked. It was working in 3.2.3 (related https://github.com/sebastianbergmann/phpunit-mock-objects/issues/322).