### PR TITLE
void return types in generateReturnValue

### DIFF
--- a/src/Framework/MockObject/Invocation/Static.php
+++ b/src/Framework/MockObject/Invocation/Static.php
@@ -121,6 +121,7 @@ class PHPUnit_Framework_MockObject_Invocation_Static implements PHPUnit_Framewor
             case 'int':    return 0;
             case 'bool':   return false;
             case 'array':  return [];
+            case 'void':   return;
 
             case 'callable':
             case 'Closure':


### PR DESCRIPTION
This solves:

```
Fatal error: Cannot use 'void' as class name as it is reserved in /home/......./vendor/phpunit/phpunit-mock-objects/src/Framework/MockObject/Generator.php(345) : eval()'d code on line 1
```