### PR TITLE
Add `withConsecutiveArray`

### DIFF
--- a/src/Framework/MockObject/Builder/InvocationMocker.php
+++ b/src/Framework/MockObject/Builder/InvocationMocker.php
@@ -251,6 +251,20 @@ class PHPUnit_Framework_MockObject_Builder_InvocationMocker implements PHPUnit_F
     }
 
     /**
+     * @param array $arguments
+     *
+     * @return PHPUnit_Framework_MockObject_Builder_InvocationMocker
+     */
+    public function withConsecutiveArray(array $arguments)
+    {
+        $this->canDefineParameters();
+
+        $this->matcher->parametersMatcher = new PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters($arguments);
+
+        return $this;
+    }
+
+    /**
      * @return PHPUnit_Framework_MockObject_Builder_InvocationMocker
      */
     public function withAnyParameters()

--- a/tests/MockObject/Matcher/ConsecutiveParametersTest.php
+++ b/tests/MockObject/Matcher/ConsecutiveParametersTest.php
@@ -18,6 +18,23 @@ class Framework_MockObject_Matcher_ConsecutiveParametersTest extends PHPUnit_Fra
         $this->assertNull($mock->foo(21, 42));
     }
 
+    public function testArrayIntegration()
+    {
+        $mock = $this->getMockBuilder(stdClass::class)
+                     ->setMethods(['foo'])
+                     ->getMock();
+
+        $mock->expects($this->any())
+             ->method('foo')
+             ->withConsecutiveArray([
+                 ['bar'],
+                 [21, 42],
+             ]);
+
+        $this->assertNull($mock->foo('bar'));
+        $this->assertNull($mock->foo(21, 42));
+    }
+
     public function testIntegrationWithLessAssertionsThanMethodCalls()
     {
         $mock = $this->getMockBuilder(stdClass::class)


### PR DESCRIPTION
Currently, there's no real way to assert a variable number of consecutive calls to a mocked method. This pull request adds a new method specifically for asserting consecutive calls with an array of the expected values.  A simplified version of the motivating code is listed here to demonstrate the need for this change.

```
        $accounts = $this->getAccounts();

        $rpc = static::getMockBuilder(BackendRpcMock::class)->setMethods([
            'saveAccount',
        ])->getMock();

        $rpc->expects($this->exactly(count($accounts)))
            ->method('saveAccount')
            ->withConsecutiveArray(array_map(function (array $account) {
                $account['password'] = '';

                return [$account];
            }, $accounts));

        app()->instance(BackendRpcInterface::class, $rpc);
```