### PR TITLE
[1.2] getMock return null for some PHP versions

### DIFF
--- a/PHPUnit/Framework/MockObject/Generator.php
+++ b/PHPUnit/Framework/MockObject/Generator.php
@@ -241,11 +241,8 @@ class PHPUnit_Framework_MockObject_Generator
                 $object = $class->newInstanceArgs($arguments);
             }
         } else {
-            // Use a trick to create a new object of a class
-            // without invoking its constructor.
-            $object = unserialize(
-              sprintf('O:%d:"%s":0:{}', strlen($className), $className)
-            );
+            $class = new ReflectionClass($className);
+            $object = $class->newInstanceWithoutConstructor();
         }
 
         return $object;


### PR DESCRIPTION
##  What? 
* Fix unserialize error `Erroneous data format for unserializing`
for some PHP versions (5.4.29, 5.5.13, 5.6.29, 5.6.26)
when calling to disable original constructor 

## How ? 
* Using Reflection instead of unserialize with sprintf 
