### PR TITLE
Do not mock method which has final class as return type

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -1117,12 +1117,25 @@ class PHPUnit_Framework_MockObject_Generator
     {
         if ($method->isConstructor() ||
             $method->isFinal() ||
+            $this->isReturnTypeFinal($method) ||
             $method->isPrivate() ||
             $this->isMethodNameBlacklisted($method->getName())) {
             return false;
         }
 
         return true;
+    }
+
+    /**
+     * @param ReflectionMethod $method
+     *
+     * @return bool
+     */
+    private function isReturnTypeFinal(ReflectionMethod $method)
+    {
+        return $this->hasReturnType($method) &&
+            class_exists($class = $method->getReturnType()->__toString()) &&
+            (new ReflectionClass($class))->isFinal();
     }
 
     /**

--- a/tests/MockObject/Generator/return_type_declarations_final.phpt
+++ b/tests/MockObject/Generator/return_type_declarations_final.phpt
@@ -1,0 +1,86 @@
+--TEST--
+PHPUnit_Framework_MockObject_Generator::generate('Foo', array(), 'MockFoo', true, true)
+--SKIPIF--
+<?php
+if (!version_compare(PHP_VERSION, '7.0', '>=')) print 'skip: PHP >= 7.0 required';
+?>
+--FILE--
+<?php
+final class FinalClass
+{
+}
+
+class Foo
+{
+    public function bar(): FinalClass
+    {
+        return new FinalClass();
+    }
+}
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+$generator = new PHPUnit_Framework_MockObject_Generator;
+
+$mock = $generator->generate(
+    'Foo',
+    array(),
+    'MockFoo',
+    true,
+    true
+);
+
+print $mock['code'];
+?>
+--EXPECTF--
+class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
+{
+    private $__phpunit_invocationMocker;
+    private $__phpunit_originalObject;
+    private $__phpunit_configurable = ['bar'];
+
+    public function __clone()
+    {
+        $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
+    }
+
+    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    {
+        return $this->__phpunit_getInvocationMocker()->expects($matcher);
+    }
+
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
+    public function __phpunit_setOriginalObject($originalObject)
+    {
+        $this->__phpunit_originalObject = $originalObject;
+    }
+
+    public function __phpunit_getInvocationMocker()
+    {
+        if ($this->__phpunit_invocationMocker === null) {
+            $this->__phpunit_invocationMocker = new PHPUnit_Framework_MockObject_InvocationMocker($this->__phpunit_configurable);
+        }
+
+        return $this->__phpunit_invocationMocker;
+    }
+
+    public function __phpunit_hasMatchers()
+    {
+        return $this->__phpunit_getInvocationMocker()->hasMatchers();
+    }
+
+    public function __phpunit_verify($unsetInvocationMocker = true)
+    {
+        $this->__phpunit_getInvocationMocker()->verify();
+
+        if ($unsetInvocationMocker) {
+            $this->__phpunit_invocationMocker = null;
+        }
+    }
+}


### PR DESCRIPTION
Hi @sebastianbergmann,

Currently for a class `Example`:
```php
class Example
{
    public function returnFinal(): FinalClass
    {
        return new FinalClass();
    }
}

final class FinalClass
{
}
```

when trying to mock:
```php
    public function testExample(): void
    {
        $example = $this->createMock(Example::class);
        $example->returnFinal();
    }
```

an error occurs:
```bash
Class "FinalClass" is declared "final" and cannot be mocked
```