### PR TITLE
Check type of expected invoke count

### DIFF
--- a/src/Builder/InvocationMocker.php
+++ b/src/Builder/InvocationMocker.php
@@ -221,7 +221,7 @@ class PHPUnit_Framework_MockObject_Builder_InvocationMocker implements PHPUnit_F
     }
 
     /**
-     * @param  array ...$arguments
+     * @param array ...$arguments
      *
      * @return PHPUnit_Framework_MockObject_Builder_InvocationMocker
      */
@@ -235,7 +235,7 @@ class PHPUnit_Framework_MockObject_Builder_InvocationMocker implements PHPUnit_F
     }
 
     /**
-     * @param  array ...$arguments
+     * @param array ...$arguments
      *
      * @return PHPUnit_Framework_MockObject_Builder_InvocationMocker
      */

--- a/src/Matcher/InvokedCount.php
+++ b/src/Matcher/InvokedCount.php
@@ -96,6 +96,15 @@ class PHPUnit_Framework_MockObject_Matcher_InvokedCount extends PHPUnit_Framewor
     {
         $count = $this->getInvocationCount();
 
+        if (is_int($this->expectedCount) === false) {
+            throw new ExpectationFailedException(
+                sprintf(
+                    'Expected an integer when comparing number of invocations, got %s',
+                    gettype($this->expectedCount)
+                )
+            );
+        }
+
         if ($count !== $this->expectedCount) {
             throw new ExpectationFailedException(
                 sprintf(

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -1037,4 +1037,27 @@ class Framework_MockObjectTest extends TestCase
             $mock->bar('call_' . $i);
         }
     }
+
+    public function testVerificationOfExpectedInvokeCountDoesThrowIfNotInteger()
+    {
+        $mock = $this->getMockBuilder(SomeClass::class)
+             ->setMethods(['foo'])
+             ->getMock();
+
+        $mock->expects($this->exactly(1.0))
+            ->method('foo');
+
+        try {
+            $mock->__phpunit_verify();
+            $this->fail('Expected exception');
+        } catch (ExpectationFailedException $e) {
+            $this->assertSame(
+                "Expectation failed for method name is equal to <string:foo> when invoked 1 time(s).\n"
+                . "Expected an integer when comparing number of invocations, got double\n",
+                $e->getMessage()
+            );
+        }
+
+        $this->resetMockObjects();
+    }
 }


### PR DESCRIPTION
Recently I encountered this issue:

`Method was expected to be called 1 times, actually called 1 times.`

While technically correct, it was time consuming to figure out why this happened. In this case it was because I was using a `dataProvider` and was programatically setting the expected count like this:

```php
$mock->expects($this->exactly(ceil($anInteger / $something))->method('foo');
```

As such it was comparing floats and integers and the expected output does not reflect that.

I hope these changes will improve on that.