### PR TITLE
Generate mock's class name using mt_rand() instead of microtime()

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -825,7 +825,7 @@ class PHPUnit_Framework_MockObject_Generator
         if ($className == '') {
             do {
                 $className = $prefix . $type . '_' .
-                             substr(md5(microtime()), 0, 8);
+                             substr(md5(mt_rand()), 0, 8);
             } while (class_exists($className, false));
         }
 


### PR DESCRIPTION
In situations where the time is frozen while running the test suite (using `runkit`, `php-timecop` or any other extension allowing that) if there's need to mock the same class more times the loop of the class name generator never ends because `microtime()` would return the same value.

Of course it's possibile to pass `$mockClassName` as a constructor's param (in `PHPUnit_Framework_TestCase::getMock()` or `PHPUnit_Framework_TestCase::getMockForAbstractClass()` just to mention two) or use a setter for the mockBuilder but most of the times that's left to the generator.

Of course there could be downsides I don't know about this so any suggestion is appreciated.