### PR TITLE
Update version schema to prevent breaking change

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.0",
         "phpunit/php-text-template": "^1.2",
-        "doctrine/instantiator": "^1.0.2",
+        "doctrine/instantiator": "~1.0.5",
         "sebastian/exporter": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Recently, [doctrine/instantiator](https://github.com/doctrine/instantiator) releases [1.1.0](https://github.com/doctrine/instantiator/releases/tag/1.1.0) version. It has breaking change that the minimum required PHP version is 7.1.0.

When use `^` operator, it is equivalent to `>=1.0.2 <2.0.0 `. ([reference](https://getcomposer.org/doc/articles/versions.md#caret-version-range-)) Thus, all users that use php 7.0 and 5.6 will not able to install this package. After changing to `~` operator, it will fix the problem. ([reference](https://getcomposer.org/doc/articles/versions.md#tilde-version-range-))