### PR TITLE
Limited instantiator dependency due to PHP change

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.0",
         "phpunit/php-text-template": "^1.2",
-        "doctrine/instantiator": "^1.0.2",
+        "doctrine/instantiator": "~1.0.2",
         "sebastian/exporter": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Doctrine has released a minor version update of instantiator (1.1) of all their packages that has a minimum requirement of PHP 7.1. Thus people using earlier (PHP 5.6 or 7.0) versions are facing issues due to this. This can be solved by capping it to 1.0.* 

Instantiator release: https://github.com/doctrine/instantiator/releases/tag/1.1.0
Issue faced: laravel/framework#20255

:)