### PR TITLE
Bump doctrine/instantiator version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.0",
         "phpunit/php-text-template": "^1.2.1",
-        "doctrine/instantiator": "^1.0.5",
+        "doctrine/instantiator": "^1.0.5|^1.1",
         "sebastian/exporter": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
While running tests through PHPUnit 6 on PHP 7, they fail because `doctrine/instantiator` requires PHP 7.1. By bumping its version to `^1.0.5|^1.1`, all PHPUnit tests pass on PHP 7.