### PR TITLE
Fix Warning message when mocking final, static, protected methods [#358]

### DIFF
--- a/src/Builder/InvocationMocker.php
+++ b/src/Builder/InvocationMocker.php
@@ -276,7 +276,8 @@ class PHPUnit_Framework_MockObject_Builder_InvocationMocker implements PHPUnit_F
         if (is_string($constraint) && !in_array(strtolower($constraint), $this->configurableMethods)) {
             throw new PHPUnit_Framework_MockObject_RuntimeException(
                 sprintf(
-                    'Trying to configure method "%s" which cannot be configured because it does not exist, has not been specified, is final, or is static',
+                    'Trying to configure method "%s" which cannot be configured because it does not exist, has not been specified, is private, is protected, is final, or is static
+',
                     $constraint
                 )
             );

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -1139,12 +1139,29 @@ class PHPUnit_Framework_MockObject_Generator
         $methods = [];
 
         foreach ($class->getMethods() as $method) {
-            if ($method->isPublic() || $method->isAbstract()) {
+            if ($this->isAvailableOutsideTheClass($method) && !$this->shouldRetainBehaviour($method)) {
                 $methods[] = $method->getName();
             }
         }
 
         return $methods;
+    }
+
+    /**
+     * @param ReflectionMethod $method
+     * @return bool
+     */
+    public function isAvailableOutsideTheClass(ReflectionMethod $method){
+        return !$method->isPrivate();
+    }
+
+    /**
+     * @param ReflectionMethod $method
+     * @return bool
+     * non final and non static methods can retain their behaviour
+     */
+    public function shouldRetainBehaviour(ReflectionMethod $method){
+        return ( $method->isFinal() || $method->isStatic() );
     }
 
     /**

--- a/tests/Generator/232.phpt
+++ b/tests/Generator/232.phpt
@@ -57,7 +57,7 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
 {
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
-    private $__phpunit_configurable = ['speak'];
+    private $__phpunit_configurable = ['speak', 'hello', 'world'];
 
     public function __clone()
     {
@@ -80,6 +80,50 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         $result = $this->__phpunit_getInvocationMocker()->invoke(
             new PHPUnit_Framework_MockObject_Invocation_Object(
                 'Foo', 'speak', $arguments, '', $this, true
+            )
+        );
+
+        return $result;
+    }
+
+    protected function hello()
+    {
+        $arguments = array();
+        $count     = func_num_args();
+
+        if ($count > 0) {
+            $_arguments = func_get_args();
+
+            for ($i = 0; $i < $count; $i++) {
+                $arguments[] = $_arguments[$i];
+            }
+        }
+
+        $result = $this->__phpunit_getInvocationMocker()->invoke(
+            new PHPUnit_Framework_MockObject_Invocation_Object(
+                'Foo', 'hello', $arguments, '', $this, true
+            )
+        );
+
+        return $result;
+    }
+
+    protected function world()
+    {
+        $arguments = array();
+        $count     = func_num_args();
+
+        if ($count > 0) {
+            $_arguments = func_get_args();
+
+            for ($i = 0; $i < $count; $i++) {
+                $arguments[] = $_arguments[$i];
+            }
+        }
+
+        $result = $this->__phpunit_getInvocationMocker()->invoke(
+            new PHPUnit_Framework_MockObject_Invocation_Object(
+                'Foo', 'world', $arguments, '', $this, true
             )
         );
 
@@ -126,4 +170,3 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
         }
     }
 }
-

--- a/tests/Generator/return_type_declarations_static_method.phpt
+++ b/tests/Generator/return_type_declarations_static_method.phpt
@@ -29,16 +29,11 @@ class MockFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
 {
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
-    private $__phpunit_configurable = ['bar'];
+    private $__phpunit_configurable = [];
 
     public function __clone()
     {
         $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
-    }
-
-    public static function bar(string $baz): Bar
-    {
-        throw new PHPUnit_Framework_MockObject_BadMethodCallException('Static method "bar" cannot be invoked on mock object');
     }
 
     public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -939,18 +939,6 @@ class Framework_MockObjectTest extends TestCase
     }
 
     /**
-     * @see    https://github.com/sebastianbergmann/phpunit-mock-objects/issues/156
-     * @ticket 156
-     */
-    public function testInterfaceWithStaticMethodCanBeStubbed()
-    {
-        $this->assertInstanceOf(
-            InterfaceWithStaticMethod::class,
-            $this->getMockBuilder(InterfaceWithStaticMethod::class)->getMock()
-        );
-    }
-
-    /**
      * @expectedException PHPUnit_Framework_MockObject_BadMethodCallException
      */
     public function testInvokingStubbedStaticMethodRaisesException()

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -729,8 +729,7 @@ class Framework_MockObjectTest extends TestCase
                 . " Array (\n"
                 . "-    0 => 'first'\n"
                 . "-    1 => 'second'\n"
-                . "+    0 => 'second'\n"
-                . " )\n",
+                . "+    0 => 'second'\n",
                 $e->getMessage()
             );
         }

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -938,16 +938,6 @@ class Framework_MockObjectTest extends TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_MockObject_BadMethodCallException
-     */
-    public function testInvokingStubbedStaticMethodRaisesException()
-    {
-        $mock = $this->getMockBuilder(ClassWithStaticMethod::class)->getMock();
-
-        $mock->staticMethod();
-    }
-
-    /**
      * @see    https://github.com/sebastianbergmann/phpunit-mock-objects/issues/171
      * @ticket 171
      */


### PR DESCRIPTION
https://github.com/sebastianbergmann/phpunit-mock-objects/issues/358