### PR TITLE
add alias willReturnConsecutiveResult

### DIFF
--- a/src/Builder/InvocationMocker.php
+++ b/src/Builder/InvocationMocker.php
@@ -174,6 +174,16 @@ class PHPUnit_Framework_MockObject_Builder_InvocationMocker implements PHPUnit_F
 
         return $this->will($stub);
     }
+    
+    /**
+     * @param mixed $values, ...
+     *
+     * @return PHPUnit_Framework_MockObject_Builder_InvocationMocker
+     */
+    public function willReturnConsecutiveResult(...$values)
+    {
+        return $this->willReturnOnConsecutiveCalls(...$values);
+    }
 
     /**
      * @param Exception $exception


### PR DESCRIPTION
Because this function will return results when call consecutive. And the tester care more about result return.