### PR TITLE
Allow mocking methods that returns generators

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -1047,6 +1047,10 @@ class Generator
 
         $returnType = (string) $method->getReturnType();
 
+        if ($returnType === \Generator::class || $returnType === \Closure::class) {
+            return false;
+        }
+
         if (\class_exists($returnType)) {
             $class = new ReflectionClass($returnType);
 

--- a/tests/Generator/return_type_declarations_closure.phpt
+++ b/tests/Generator/return_type_declarations_closure.phpt
@@ -1,0 +1,97 @@
+--TEST--
+\PHPUnit\Framework\MockObject\Generator::generate('Foo', array(), 'MockFoo', true, true)
+--FILE--
+<?php
+interface Foo
+{
+    public function bar(): Closure;
+}
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$generator = new \PHPUnit\Framework\MockObject\Generator;
+
+$mock = $generator->generate(
+    'Foo',
+    array(),
+    'MockFoo',
+    true,
+    true
+);
+
+print $mock['code'];
+?>
+--EXPECTF--
+class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
+{
+    private $__phpunit_invocationMocker;
+    private $__phpunit_originalObject;
+    private $__phpunit_configurable = ['bar'];
+
+    public function __clone()
+    {
+        $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
+    }
+
+    public function bar(): Closure
+    {
+        $arguments = array();
+        $count     = func_num_args();
+
+        if ($count > 0) {
+            $_arguments = func_get_args();
+
+            for ($i = 0; $i < $count; $i++) {
+                $arguments[] = $_arguments[$i];
+            }
+        }
+
+        $result = $this->__phpunit_getInvocationMocker()->invoke(
+            new \PHPUnit\Framework\MockObject\Invocation\ObjectInvocation(
+                'Foo', 'bar', $arguments, 'Closure', $this, true
+            )
+        );
+
+        return $result;
+    }
+
+    public function expects(\PHPUnit\Framework\MockObject\Matcher\Invocation $matcher)
+    {
+        return $this->__phpunit_getInvocationMocker()->expects($matcher);
+    }
+
+    public function method()
+    {
+        $any = new \PHPUnit\Framework\MockObject\Matcher\AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
+    public function __phpunit_setOriginalObject($originalObject)
+    {
+        $this->__phpunit_originalObject = $originalObject;
+    }
+
+    public function __phpunit_getInvocationMocker()
+    {
+        if ($this->__phpunit_invocationMocker === null) {
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+        }
+
+        return $this->__phpunit_invocationMocker;
+    }
+
+    public function __phpunit_hasMatchers()
+    {
+        return $this->__phpunit_getInvocationMocker()->hasMatchers();
+    }
+
+    public function __phpunit_verify($unsetInvocationMocker = true)
+    {
+        $this->__phpunit_getInvocationMocker()->verify();
+
+        if ($unsetInvocationMocker) {
+            $this->__phpunit_invocationMocker = null;
+        }
+    }
+}

--- a/tests/Generator/return_type_declarations_generator.phpt
+++ b/tests/Generator/return_type_declarations_generator.phpt
@@ -1,0 +1,97 @@
+--TEST--
+\PHPUnit\Framework\MockObject\Generator::generate('Foo', array(), 'MockFoo', true, true)
+--FILE--
+<?php
+interface Foo
+{
+    public function bar(): Generator;
+}
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$generator = new \PHPUnit\Framework\MockObject\Generator;
+
+$mock = $generator->generate(
+    'Foo',
+    array(),
+    'MockFoo',
+    true,
+    true
+);
+
+print $mock['code'];
+?>
+--EXPECTF--
+class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
+{
+    private $__phpunit_invocationMocker;
+    private $__phpunit_originalObject;
+    private $__phpunit_configurable = ['bar'];
+
+    public function __clone()
+    {
+        $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
+    }
+
+    public function bar(): Generator
+    {
+        $arguments = array();
+        $count     = func_num_args();
+
+        if ($count > 0) {
+            $_arguments = func_get_args();
+
+            for ($i = 0; $i < $count; $i++) {
+                $arguments[] = $_arguments[$i];
+            }
+        }
+
+        $result = $this->__phpunit_getInvocationMocker()->invoke(
+            new \PHPUnit\Framework\MockObject\Invocation\ObjectInvocation(
+                'Foo', 'bar', $arguments, 'Generator', $this, true
+            )
+        );
+
+        return $result;
+    }
+
+    public function expects(\PHPUnit\Framework\MockObject\Matcher\Invocation $matcher)
+    {
+        return $this->__phpunit_getInvocationMocker()->expects($matcher);
+    }
+
+    public function method()
+    {
+        $any = new \PHPUnit\Framework\MockObject\Matcher\AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
+    public function __phpunit_setOriginalObject($originalObject)
+    {
+        $this->__phpunit_originalObject = $originalObject;
+    }
+
+    public function __phpunit_getInvocationMocker()
+    {
+        if ($this->__phpunit_invocationMocker === null) {
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+        }
+
+        return $this->__phpunit_invocationMocker;
+    }
+
+    public function __phpunit_hasMatchers()
+    {
+        return $this->__phpunit_getInvocationMocker()->hasMatchers();
+    }
+
+    public function __phpunit_verify($unsetInvocationMocker = true)
+    {
+        $this->__phpunit_getInvocationMocker()->verify();
+
+        if ($unsetInvocationMocker) {
+            $this->__phpunit_invocationMocker = null;
+        }
+    }
+}


### PR DESCRIPTION
Because of #386 we can no longer mock methods that uses `\Generator` or `\Closure` as return type. This fixes it.