### PR TITLE
Fixed PHPUnit\Framework\MockObject\Invocation usage in Matcher/* classes

### DIFF
--- a/src/Matcher/AnyParameters.php
+++ b/src/Matcher/AnyParameters.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\Framework\MockObject\Matcher;
 
-use PHPUnit\Framework\MockObject\Invocation;
+use PHPUnit\Framework\MockObject\Invocation as BaseInvocation;
 
 /**
  * Invocation matcher which allows any parameters to a method.
@@ -25,11 +25,11 @@ class AnyParameters extends StatelessInvocation
     }
 
     /**
-     * @param Invocation $invocation
+     * @param BaseInvocation $invocation
      *
      * @return bool
      */
-    public function matches(Invocation $invocation)
+    public function matches(BaseInvocation $invocation)
     {
         return true;
     }

--- a/src/Matcher/InvokedCount.php
+++ b/src/Matcher/InvokedCount.php
@@ -10,7 +10,7 @@
 namespace PHPUnit\Framework\MockObject\Matcher;
 
 use PHPUnit\Framework\ExpectationFailedException;
-use PHPUnit\Framework\MockObject\Invocation;
+use PHPUnit\Framework\MockObject\Invocation as BaseInvocation;
 
 /**
  * Invocation matcher which checks if a method has been invoked a certain amount
@@ -52,11 +52,11 @@ class InvokedCount extends InvokedRecorder
     }
 
     /**
-     * @param Invocation $invocation
+     * @param BaseInvocation $invocation
      *
      * @throws ExpectationFailedException
      */
-    public function invoked(Invocation $invocation)
+    public function invoked(BaseInvocation $invocation)
     {
         parent::invoked($invocation);
 

--- a/src/Matcher/MethodName.php
+++ b/src/Matcher/MethodName.php
@@ -11,7 +11,7 @@ namespace PHPUnit\Framework\MockObject\Matcher;
 
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\IsEqual;
-use PHPUnit\Framework\MockObject\Invocation;
+use PHPUnit\Framework\MockObject\Invocation as BaseInvocation;
 use PHPUnit\Util\InvalidArgumentHelper;
 
 /**
@@ -62,11 +62,11 @@ class MethodName extends StatelessInvocation
     }
 
     /**
-     * @param Invocation $invocation
+     * @param BaseInvocation $invocation
      *
      * @return bool
      */
-    public function matches(Invocation $invocation)
+    public function matches(BaseInvocation $invocation)
     {
         return $this->constraint->evaluate($invocation->getMethodName(), '', true);
     }


### PR DESCRIPTION
Not all classes was correctly refactored for namespace usage