### PR TITLE
Malformed withConsecutive doesn't raise errors

### DIFF
--- a/tests/Matcher/ConsecutiveParametersTest.php
+++ b/tests/Matcher/ConsecutiveParametersTest.php
@@ -65,4 +65,22 @@ class ConsecutiveParametersTest extends TestCase
 
         $mock->foo('invalid');
     }
+
+    public function testMalformedConstraintIntegrationExpectingException()
+    {
+        $mock = $this->getMockBuilder(stdClass::class)
+                     ->setMethods(['foo'])
+                     ->getMock();
+
+        $mock->expects($this->any())
+             ->method('foo')
+             ->withConsecutive(
+                 // Note the absence of array
+                 $this->stringContains('bar')
+             );
+
+        $this->expectException(\PHPUnit\Exception::class);
+
+        $mock->foo('invalid');
+    }
 }


### PR DESCRIPTION
Ref: https://github.com/sebastianbergmann/phpunit-mock-objects/pull/359

Each `withConsecutive` parameter should be an array (or Traversable) in order to be used by [Matcher/ConsecutiveParameters.php](https://github.com/sebastianbergmann/phpunit-mock-objects/blob/4.0.1/src/Matcher/ConsecutiveParameters.php#L43) and I would expect an error if the expectation is malformed.

Instead the test passes, but should fail.

PS: I don't get why you directly closed the PR instead of asking me to rebase 😕 