### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Builder/InvocationMockerTest.php
+++ b/tests/Builder/InvocationMockerTest.php
@@ -65,7 +65,7 @@ class InvocationMockerTest extends TestCase
              ->method('foo')
              ->willReturnReference($value);
 
-        $this->assertSame(null, $mock->foo());
+        $this->assertNull($mock->foo());
         $value = 'foo';
         $this->assertSame('foo', $mock->foo());
         $value = 'bar';

--- a/tests/MockBuilderTest.php
+++ b/tests/MockBuilderTest.php
@@ -17,7 +17,7 @@ class MockBuilderTest extends TestCase
     {
         $mock = $this->getMockBuilder(Mockable::class)->getMock();
 
-        $this->assertTrue($mock instanceof Mockable);
+        $this->assertInstanceOf(Mockable::class, $mock);
     }
 
     public function testByDefaultMocksAllMethods()
@@ -71,7 +71,7 @@ class MockBuilderTest extends TestCase
                      ->setMockClassName('ACustomClassName')
                      ->getMock();
 
-        $this->assertTrue($mock instanceof ACustomClassName);
+        $this->assertInstanceOf(ACustomClassName::class, $mock);
     }
 
     public function testConstructorArgumentsCanBeSpecified()
@@ -124,6 +124,6 @@ class MockBuilderTest extends TestCase
                      ->disableOriginalClone()
                      ->disableAutoload();
 
-        $this->assertTrue($spec instanceof MockBuilder);
+        $this->assertInstanceOf(MockBuilder::class, $spec);
     }
 }

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -229,7 +229,7 @@ class MockObjectTest extends TestCase
 
         $this->assertEquals('d', $mock->doSomething('a', 'b', 'c'));
         $this->assertEquals('h', $mock->doSomething('e', 'f', 'g'));
-        $this->assertEquals(null, $mock->doSomething('foo', 'bar'));
+        $this->assertNull($mock->doSomething('foo', 'bar'));
 
         $mock = $this->getMockBuilder(AnInterface::class)
                      ->getMock();
@@ -240,7 +240,7 @@ class MockObjectTest extends TestCase
 
         $this->assertEquals('d', $mock->doSomething('a', 'b', 'c'));
         $this->assertEquals('h', $mock->doSomething('e', 'f', 'g'));
-        $this->assertEquals(null, $mock->doSomething('foo', 'bar'));
+        $this->assertNull($mock->doSomething('foo', 'bar'));
     }
 
     public function testStubbedReturnArgument()
@@ -598,7 +598,7 @@ class MockObjectTest extends TestCase
 
         $mock->doSomethingElse($expectedObject);
 
-        $this->assertEquals(1, count($actualArguments));
+        $this->assertCount(1, $actualArguments);
         $this->assertEquals($expectedObject, $actualArguments[0]);
         $this->assertNotSame($expectedObject, $actualArguments[0]);
     }
@@ -626,7 +626,7 @@ class MockObjectTest extends TestCase
 
         $mock->doSomethingElse($expectedObject);
 
-        $this->assertEquals(1, count($actualArguments));
+        $this->assertCount(1, $actualArguments);
         $this->assertSame($expectedObject, $actualArguments[0]);
     }
 


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertInstanceOf` instead of `instanceof` operator;
- `assertNull` instead of comparison with `null` keyword.