### PR TITLE
Disable automatic return value generation

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -67,6 +67,7 @@ class Generator
      * @param bool            $callOriginalMethods
      * @param object          $proxyTarget
      * @param bool            $allowMockingUnknownTypes
+     * @param bool            $returnValueGeneration
      *
      * @throws Exception
      * @throws RuntimeException
@@ -75,7 +76,7 @@ class Generator
      *
      * @return MockObject
      */
-    public function getMock($type, $methods = [], array $arguments = [], $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $cloneArguments = true, $callOriginalMethods = false, $proxyTarget = null, $allowMockingUnknownTypes = true)
+    public function getMock($type, $methods = [], array $arguments = [], $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $cloneArguments = true, $callOriginalMethods = false, $proxyTarget = null, $allowMockingUnknownTypes = true, $returnValueGeneration = true)
     {
         if (!\is_array($type) && !\is_string($type)) {
             throw InvalidArgumentHelper::factory(1, 'array or string');
@@ -197,7 +198,8 @@ class Generator
             $callAutoload,
             $arguments,
             $callOriginalMethods,
-            $proxyTarget
+            $proxyTarget,
+            $returnValueGeneration
         );
     }
 
@@ -549,13 +551,14 @@ class Generator
      * @param array        $arguments
      * @param bool         $callOriginalMethods
      * @param object       $proxyTarget
+     * @param bool         $returnValueGeneration
      *
      * @throws \ReflectionException
      * @throws RuntimeException
      *
      * @return MockObject
      */
-    private function getObject($code, $className, $type = '', $callOriginalConstructor = false, $callAutoload = false, array $arguments = [], $callOriginalMethods = false, $proxyTarget = null)
+    private function getObject($code, $className, $type = '', $callOriginalConstructor = false, $callAutoload = false, array $arguments = [], $callOriginalMethods = false, $proxyTarget = null, $returnValueGeneration = true)
     {
         $this->evalClass($code, $className);
 
@@ -589,6 +592,8 @@ class Generator
 
             $object->__phpunit_setOriginalObject($proxyTarget);
         }
+
+        $object->__phpunit_setReturnValueGeneration($returnValueGeneration);
 
         return $object;
     }

--- a/src/Generator/mocked_class.tpl.dist
+++ b/src/Generator/mocked_class.tpl.dist
@@ -3,6 +3,7 @@
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = {configurable};
+    private $__phpunit_returnValueGeneration = true;
 
 {clone}{mocked_methods}
     public function expects(\PHPUnit\Framework\MockObject\Matcher\Invocation $matcher)
@@ -15,10 +16,15 @@
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/src/InvocationMocker.php
+++ b/src/InvocationMocker.php
@@ -51,7 +51,7 @@ class InvocationMocker implements MatcherCollection, Invokable, NamespaceMatch
      * @param array $configurableMethods
      * @param bool  $returnValueGeneration
      */
-    public function __construct(array $configurableMethods, $returnValueGeneration)
+    public function __construct(array $configurableMethods, bool $returnValueGeneration)
     {
         $this->configurableMethods = $configurableMethods;
         $this->returnValueGeneration = $returnValueGeneration;

--- a/src/InvocationMocker.php
+++ b/src/InvocationMocker.php
@@ -10,10 +10,13 @@
 namespace PHPUnit\Framework\MockObject;
 
 use Exception;
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\MockObject\Builder\InvocationMocker as BuilderInvocationMocker;
 use PHPUnit\Framework\MockObject\Builder\Match;
 use PHPUnit\Framework\MockObject\Builder\NamespaceMatch;
+use PHPUnit\Framework\MockObject\Invocation as BaseInvocation;
 use PHPUnit\Framework\MockObject\Matcher\Invocation as MatcherInvocation;
+use PHPUnit\Framework\MockObject\Matcher\StatelessInvocation;
 use PHPUnit\Framework\MockObject\Stub\MatcherCollection;
 
 /**
@@ -41,11 +44,18 @@ class InvocationMocker implements MatcherCollection, Invokable, NamespaceMatch
     private $configurableMethods = [];
 
     /**
-     * @param array $configurableMethods
+     * @var bool
      */
-    public function __construct(array $configurableMethods)
+    private $returnValueGeneration;
+
+    /**
+     * @param array $configurableMethods
+     * @param bool  $returnValueGeneration
+     */
+    public function __construct(array $configurableMethods, $returnValueGeneration)
     {
         $this->configurableMethods = $configurableMethods;
+        $this->returnValueGeneration = $returnValueGeneration;
     }
 
     /**
@@ -146,6 +156,54 @@ class InvocationMocker implements MatcherCollection, Invokable, NamespaceMatch
 
         if ($hasReturnValue) {
             return $returnValue;
+        }
+
+        if ($this->returnValueGeneration === false) {
+            $exception = new ExpectationFailedException(
+                sprintf(
+                    "Return value inference disabled and no expectation set up for %s::%s()",
+                    $invocation->getClassName(),
+                    $invocation->getMethodName()
+                )
+            );
+
+            if (\strtolower($invocation->getMethodName()) === '__tostring') {
+                $this->addMatcher(
+                    new class($exception) extends StatelessInvocation
+                    {
+                        private $exception;
+
+                        public function __construct(\Throwable $exception)
+                        {
+                            $this->exception = $exception;
+                        }
+
+                        public function matches(BaseInvocation $invocation)
+                        {
+                            return false;
+                        }
+
+                        public function hasMatchers(): bool
+                        {
+                            return false;
+                        }
+
+                        public function toString(): string
+                        {
+                            return '';
+                        }
+
+                        public function verify()
+                        {
+                            throw $this->exception;
+                        }
+                    }
+                );
+
+                return '';
+            }
+
+            throw $exception;
         }
 
         return $invocation->generateReturnValue();

--- a/src/InvocationMocker.php
+++ b/src/InvocationMocker.php
@@ -14,9 +14,8 @@ use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\MockObject\Builder\InvocationMocker as BuilderInvocationMocker;
 use PHPUnit\Framework\MockObject\Builder\Match;
 use PHPUnit\Framework\MockObject\Builder\NamespaceMatch;
-use PHPUnit\Framework\MockObject\Invocation as BaseInvocation;
+use PHPUnit\Framework\MockObject\Matcher\DeferredError;
 use PHPUnit\Framework\MockObject\Matcher\Invocation as MatcherInvocation;
-use PHPUnit\Framework\MockObject\Matcher\StatelessInvocation;
 use PHPUnit\Framework\MockObject\Stub\MatcherCollection;
 
 /**
@@ -168,37 +167,7 @@ class InvocationMocker implements MatcherCollection, Invokable, NamespaceMatch
             );
 
             if (\strtolower($invocation->getMethodName()) === '__tostring') {
-                $this->addMatcher(
-                    new class($exception) extends StatelessInvocation
-                    {
-                        private $exception;
-
-                        public function __construct(\Throwable $exception)
-                        {
-                            $this->exception = $exception;
-                        }
-
-                        public function matches(BaseInvocation $invocation)
-                        {
-                            return false;
-                        }
-
-                        public function hasMatchers(): bool
-                        {
-                            return false;
-                        }
-
-                        public function toString(): string
-                        {
-                            return '';
-                        }
-
-                        public function verify()
-                        {
-                            throw $this->exception;
-                        }
-                    }
-                );
+                $this->addMatcher(new DeferredError($exception));
 
                 return '';
             }

--- a/src/Matcher/DeferredError.php
+++ b/src/Matcher/DeferredError.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * This file is part of the phpunit-mock-objects package.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject\Matcher;
+use PHPUnit\Framework\MockObject\Invocation as BaseInvocation;
+
+class DeferredError extends StatelessInvocation
+{
+    /**
+     * @var \Throwable
+     */
+    private $exception;
+
+    public function __construct(\Throwable $exception)
+    {
+        $this->exception = $exception;
+    }
+
+    public function verify()
+    {
+        throw $this->exception;
+    }
+
+    public function toString(): string
+    {
+        return '';
+    }
+
+    public function matches(BaseInvocation $invocation)
+    {
+        return true;
+    }
+}

--- a/src/Matcher/DeferredError.php
+++ b/src/Matcher/DeferredError.php
@@ -22,7 +22,7 @@ class DeferredError extends StatelessInvocation
         $this->exception = $exception;
     }
 
-    public function verify()
+    public function verify(): void
     {
         throw $this->exception;
     }
@@ -32,7 +32,7 @@ class DeferredError extends StatelessInvocation
         return '';
     }
 
-    public function matches(BaseInvocation $invocation)
+    public function matches(BaseInvocation $invocation): bool
     {
         return true;
     }

--- a/src/MockBuilder.php
+++ b/src/MockBuilder.php
@@ -82,6 +82,11 @@ class MockBuilder
     private $allowMockingUnknownTypes = true;
 
     /**
+     * @var bool
+     */
+    private $returnValueGeneration = true;
+
+    /**
      * @var Generator
      */
     private $generator;
@@ -115,7 +120,8 @@ class MockBuilder
             $this->cloneArguments,
             $this->callOriginalMethods,
             $this->proxyTarget,
-            $this->allowMockingUnknownTypes
+            $this->allowMockingUnknownTypes,
+            $this->returnValueGeneration
         );
 
         $this->testCase->registerMockObject($object);
@@ -383,6 +389,26 @@ class MockBuilder
     public function disallowMockingUnknownTypes()
     {
         $this->allowMockingUnknownTypes = false;
+
+        return $this;
+    }
+
+    /**
+     * @return MockBuilder
+     */
+    public function enableAutoReturnValueGeneration()
+    {
+        $this->returnValueGeneration = true;
+
+        return $this;
+    }
+
+    /**
+     * @return MockBuilder
+     */
+    public function disableAutoReturnValueGeneration()
+    {
+        $this->returnValueGeneration = false;
 
         return $this;
     }

--- a/src/MockObject.php
+++ b/src/MockObject.php
@@ -45,6 +45,8 @@ interface PHPUnit_Framework_MockObject_MockObject /*extends Verifiable*/
      */
     public function __phpunit_hasMatchers();
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration);
+
     /**
      * Registers a new expectation in the mock object and returns the match
      * object which can be infused with further details.

--- a/tests/Generator/232.phpt
+++ b/tests/Generator/232.phpt
@@ -58,6 +58,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['speak'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -104,10 +105,15 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/397.phpt
+++ b/tests/Generator/397.phpt
@@ -28,6 +28,7 @@ class MockC extends C implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['m'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -74,10 +75,15 @@ class MockC extends C implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/abstract_class.phpt
+++ b/tests/Generator/abstract_class.phpt
@@ -33,6 +33,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['one', 'two', 'three'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -123,10 +124,15 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/class.phpt
+++ b/tests/Generator/class.phpt
@@ -33,6 +33,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['bar', 'baz'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -101,10 +102,15 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/class_call_parent_clone.phpt
+++ b/tests/Generator/class_call_parent_clone.phpt
@@ -28,6 +28,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = [];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -53,10 +54,15 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/class_call_parent_constructor.phpt
+++ b/tests/Generator/class_call_parent_constructor.phpt
@@ -28,6 +28,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = [];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -52,10 +53,15 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/class_dont_call_parent_clone.phpt
+++ b/tests/Generator/class_dont_call_parent_clone.phpt
@@ -28,6 +28,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = [];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -52,10 +53,15 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/class_dont_call_parent_constructor.phpt
+++ b/tests/Generator/class_dont_call_parent_constructor.phpt
@@ -28,6 +28,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = [];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -52,10 +53,15 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/class_implementing_interface_call_parent_constructor.phpt
+++ b/tests/Generator/class_implementing_interface_call_parent_constructor.phpt
@@ -33,6 +33,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = [];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -57,10 +58,15 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/class_implementing_interface_dont_call_parent_constructor.phpt
+++ b/tests/Generator/class_implementing_interface_dont_call_parent_constructor.phpt
@@ -33,6 +33,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = [];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -57,10 +58,15 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/class_partial.phpt
+++ b/tests/Generator/class_partial.phpt
@@ -33,6 +33,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['bar'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -79,10 +80,15 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/class_with_deprecated_method.phpt
+++ b/tests/Generator/class_with_deprecated_method.phpt
@@ -33,6 +33,7 @@ class MockFoo extends ClassWithDeprecatedMethod implements PHPUnit\Framework\Moc
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['deprecatedmethod'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -81,10 +82,15 @@ class MockFoo extends ClassWithDeprecatedMethod implements PHPUnit\Framework\Moc
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/class_with_method_named_method.phpt
+++ b/tests/Generator/class_with_method_named_method.phpt
@@ -29,6 +29,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['method'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -67,10 +68,15 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/class_with_method_with_nullable_typehinted_variadic_arguments.phpt
+++ b/tests/Generator/class_with_method_with_nullable_typehinted_variadic_arguments.phpt
@@ -29,6 +29,7 @@ class MockFoo extends ClassWithMethodWithNullableTypehintedVariadicArguments imp
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['methodwithnullabletypehintedvariadicarguments'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -75,10 +76,15 @@ class MockFoo extends ClassWithMethodWithNullableTypehintedVariadicArguments imp
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/class_with_method_with_typehinted_variadic_arguments.phpt
+++ b/tests/Generator/class_with_method_with_typehinted_variadic_arguments.phpt
@@ -29,6 +29,7 @@ class MockFoo extends ClassWithMethodWithTypehintedVariadicArguments implements 
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['methodwithtypehintedvariadicarguments'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -75,10 +76,15 @@ class MockFoo extends ClassWithMethodWithTypehintedVariadicArguments implements 
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/class_with_method_with_variadic_arguments.phpt
+++ b/tests/Generator/class_with_method_with_variadic_arguments.phpt
@@ -29,6 +29,7 @@ class MockFoo extends ClassWithMethodWithVariadicArguments implements PHPUnit\Fr
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['methodwithvariadicarguments'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -75,10 +76,15 @@ class MockFoo extends ClassWithMethodWithVariadicArguments implements PHPUnit\Fr
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/interface.phpt
+++ b/tests/Generator/interface.phpt
@@ -27,6 +27,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['bar'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -73,10 +74,15 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/invocation_object_clone_object.phpt
+++ b/tests/Generator/invocation_object_clone_object.phpt
@@ -34,6 +34,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['bar', 'baz'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -102,10 +103,15 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/namespaced_class.phpt
+++ b/tests/Generator/namespaced_class.phpt
@@ -35,6 +35,7 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['bar', 'baz'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -103,10 +104,15 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/namespaced_class_call_parent_clone.phpt
+++ b/tests/Generator/namespaced_class_call_parent_clone.phpt
@@ -30,6 +30,7 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = [];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -55,10 +56,15 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/namespaced_class_call_parent_constructor.phpt
+++ b/tests/Generator/namespaced_class_call_parent_constructor.phpt
@@ -30,6 +30,7 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = [];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -54,10 +55,15 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/namespaced_class_dont_call_parent_clone.phpt
+++ b/tests/Generator/namespaced_class_dont_call_parent_clone.phpt
@@ -30,6 +30,7 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = [];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -54,10 +55,15 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/namespaced_class_dont_call_parent_constructor.phpt
+++ b/tests/Generator/namespaced_class_dont_call_parent_constructor.phpt
@@ -30,6 +30,7 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = [];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -54,10 +55,15 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/namespaced_class_implementing_interface_call_parent_constructor.phpt
+++ b/tests/Generator/namespaced_class_implementing_interface_call_parent_constructor.phpt
@@ -35,6 +35,7 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = [];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -59,10 +60,15 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/namespaced_class_implementing_interface_dont_call_parent_constructor.phpt
+++ b/tests/Generator/namespaced_class_implementing_interface_dont_call_parent_constructor.phpt
@@ -35,6 +35,7 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = [];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -59,10 +60,15 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/namespaced_class_partial.phpt
+++ b/tests/Generator/namespaced_class_partial.phpt
@@ -35,6 +35,7 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['bar'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -81,10 +82,15 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/namespaced_interface.phpt
+++ b/tests/Generator/namespaced_interface.phpt
@@ -29,6 +29,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, NS\Foo
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['bar'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -75,10 +76,15 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, NS\Foo
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/nonexistent_class.phpt
+++ b/tests/Generator/nonexistent_class.phpt
@@ -26,6 +26,7 @@ class MockFoo extends NonExistentClass implements PHPUnit\Framework\MockObject\M
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = [];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -50,10 +51,15 @@ class MockFoo extends NonExistentClass implements PHPUnit\Framework\MockObject\M
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/nonexistent_class_with_namespace.phpt
+++ b/tests/Generator/nonexistent_class_with_namespace.phpt
@@ -32,6 +32,7 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = [];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -56,10 +57,15 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/nonexistent_class_with_namespace_starting_with_separator.phpt
+++ b/tests/Generator/nonexistent_class_with_namespace_starting_with_separator.phpt
@@ -32,6 +32,7 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = [];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -56,10 +57,15 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/nullable_types.phpt
+++ b/tests/Generator/nullable_types.phpt
@@ -29,6 +29,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['bar'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -75,10 +76,15 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/proxy.phpt
+++ b/tests/Generator/proxy.phpt
@@ -29,6 +29,7 @@ class ProxyFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['bar', 'baz'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -97,10 +98,15 @@ class ProxyFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/return_type_declarations_closure.phpt
+++ b/tests/Generator/return_type_declarations_closure.phpt
@@ -27,6 +27,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['bar'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -73,10 +74,15 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/return_type_declarations_final.phpt
+++ b/tests/Generator/return_type_declarations_final.phpt
@@ -34,6 +34,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['bar'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -80,10 +81,15 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/return_type_declarations_generator.phpt
+++ b/tests/Generator/return_type_declarations_generator.phpt
@@ -27,6 +27,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['bar'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -73,10 +74,15 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/return_type_declarations_nullable.phpt
+++ b/tests/Generator/return_type_declarations_nullable.phpt
@@ -27,6 +27,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['bar'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -73,10 +74,15 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/return_type_declarations_object_method.phpt
+++ b/tests/Generator/return_type_declarations_object_method.phpt
@@ -30,6 +30,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['bar'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -76,10 +77,15 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/return_type_declarations_parent.phpt
+++ b/tests/Generator/return_type_declarations_parent.phpt
@@ -33,6 +33,7 @@ class MockBar extends Bar implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['baz'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -79,10 +80,15 @@ class MockBar extends Bar implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/return_type_declarations_self.phpt
+++ b/tests/Generator/return_type_declarations_self.phpt
@@ -27,6 +27,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['bar'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -73,10 +74,15 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/return_type_declarations_static_method.phpt
+++ b/tests/Generator/return_type_declarations_static_method.phpt
@@ -30,6 +30,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['bar'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -59,10 +60,15 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/return_type_declarations_void.phpt
+++ b/tests/Generator/return_type_declarations_void.phpt
@@ -27,6 +27,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['bar'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -71,10 +72,15 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/Generator/scalar_type_declarations.phpt
+++ b/tests/Generator/scalar_type_declarations.phpt
@@ -29,6 +29,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;
     private $__phpunit_configurable = ['bar'];
+    private $__phpunit_returnValueGeneration = true;
 
     public function __clone()
     {
@@ -75,10 +76,15 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
         $this->__phpunit_originalObject = $originalObject;
     }
 
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
     public function __phpunit_getInvocationMocker()
     {
         if ($this->__phpunit_invocationMocker === null) {
-            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable);
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
         }
 
         return $this->__phpunit_invocationMocker;

--- a/tests/MockObjectTest.php
+++ b/tests/MockObjectTest.php
@@ -1052,6 +1052,41 @@ class MockObjectTest extends TestCase
         $this->assertInstanceOf(MockObject::class, $stub->methodWithClassReturnTypeDeclaration());
     }
 
+    public function testDisableAutomaticReturnValueGeneration()
+    {
+        $mock = $this->getMockBuilder(SomeClass::class)
+            ->disableAutoReturnValueGeneration()
+            ->getMock();
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage(
+            'Return value inference disabled and no expectation set up for SomeClass::doSomethingElse()'
+        );
+
+        $mock->doSomethingElse(1);
+    }
+
+    public function testDisableAutomaticReturnValueGenerationWithToString()
+    {
+        $mock = $this->getMockBuilder(StringableClass::class)
+            ->disableAutoReturnValueGeneration()
+            ->getMock();
+
+        (string) $mock;
+
+        try {
+            $mock->__phpunit_verify();
+            $this->fail('Exception expected');
+        } catch (ExpectationFailedException $e) {
+            $this->assertSame(
+                'Return value inference disabled and no expectation set up for StringableClass::__toString()',
+                $e->getMessage()
+            );
+        }
+
+        $this->resetMockObjects();
+    }
+
     /**
      * @requires PHP 7.1
      */


### PR DESCRIPTION
The automatic return value inference makes it oftentimes harder to do wider refactorings across bigger code bases. This PR should serve as a discussion starter to add a mocking mode, that turns this feature off.

## TODO
- [ ] What to do with `createMock()`, `createConfiguredMock()` etc. Idea would be to add `createStrictMock()`, `createConfiguredStrictMock()`