### PR TITLE
Fix v2.3 to allow mock with a `types` array such as ['class', 'interface1']

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,28 @@
 language: php
 
+matrix:
+  include:
+    - php: 5.3.3
+      dist: precise
+    - php: 5.3
+      dist: precise
+  allow_failures:
+    - php: hhvm
+  fast_finish: true
+
+cache:
+  directories:
+    - vendor
+    - $HOME/.composer/cache
+
 before_script:
-  - composer self-update
-  - composer install --no-interaction --prefer-source --dev
+  - if [[ $TRAVIS_PHP_VERSION = 5.3.3 ]]; then composer config -g -- disable-tls true; composer config -g -- secure-http false; fi;
+  - travis_retry composer self-update
+  - travis_retry composer install --no-interaction --prefer-source --dev
 
 script: ./vendor/bin/phpunit --configuration ./build/travis-ci.xml
 
 php:
-  - 5.3.3
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/src/Framework/MockObject/Generator/proxied_method.tpl.dist
+++ b/src/Framework/MockObject/Generator/proxied_method.tpl.dist
@@ -12,11 +12,11 @@
             }
         }
 
-        $this->__phpunit_getInvocationMocker()->invoke(
+        $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
             '{class_name}', '{method_name}', $arguments, $this, {clone_arguments}
           )
         );
 
-        return call_user_func_array(array($this->__phpunit_originalObject, "{method_name}"), $arguments);
+        return isset($result) ? $result : call_user_func_array(array($this->__phpunit_originalObject, '{method_name}'), $arguments);
     }

--- a/src/Framework/MockObject/Stub/ReturnCallback.php
+++ b/src/Framework/MockObject/Stub/ReturnCallback.php
@@ -44,7 +44,8 @@ class PHPUnit_Framework_MockObject_Stub_ReturnCallback implements PHPUnit_Framew
                 $this->callback[1]
             );
         } else {
-            return 'return result of user defined callback ' . $this->callback .
+            return 'return result of user defined callback ' .
+                   ($this->callback instanceof Closure ? 'Closure' : $this->callback) .
                    ' with the passed arguments';
         }
     }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -12,6 +12,53 @@ class Framework_MockObject_GeneratorTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getMockObjectGenerator()
+    {
+        return $this->generator;
+    }
+
+    /**
+     * @covers PHPUnit_Framework_MockObject_Generator::getMock
+     * @expectedException PHPUnit_Framework_Exception
+     * @expectedExceptionMessage Argument #1 (No Value) of PHPUnit_Framework_MockObject_Generator::getMock() must be a array or string
+     */
+    public function testGetMockForInvalidType()
+    {
+        $this->generator->getMock(false);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_MockObject_Generator::getMock
+     * @expectedException InvalidArgumentException
+     */
+    public function testGetMockForInvalidMethods()
+    {
+        $this->generator->getMock('', '');
+    }
+
+    /**
+     * @covers PHPUnit_Framework_MockObject_Generator::getMock
+     * @expectedException PHPUnit_Framework_Exception
+     * @expectedExceptionMessage Argument #4 (No Value) of PHPUnit_Framework_MockObject_Generator::getMock() must be a string
+     */
+    public function testGetMockForInvalidMockClassName()
+    {
+        $this->generator->getMock('', array(), array(), false);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_MockObject_Generator::getMock
+     * @expectedException PHPUnit_Framework_MockObject_RuntimeException
+     * @expectedExceptionMessage Class "Framework_MockObject_GeneratorTest" already exists.
+     */
+    public function testGetMockForAlreadyExistsMockClassName()
+    {
+        $this->generator->getMock('', null, array(), get_class($this));
+    }
+
+    /**
      * @covers PHPUnit_Framework_MockObject_Generator::getMock
      * @expectedException PHPUnit_Framework_Exception
      */
@@ -81,7 +128,7 @@ class Framework_MockObject_GeneratorTest extends PHPUnit_Framework_TestCase
      */
     public function testGetMockForAbstractClassShouldCreateStubsOnlyForAbstractMethodWhenNoMethodsWereInformed()
     {
-        $mock = $this->generator->getMockForAbstractClass('AbstractMockTestClass');
+        $mock = $this->getMockForAbstractClass('AbstractMockTestClass');
 
         $mock->expects($this->any())
              ->method('doSomething')
@@ -119,6 +166,52 @@ class Framework_MockObject_GeneratorTest extends PHPUnit_Framework_TestCase
             'className not a string' => array(array(), ''),
             'mockClassName not a string' => array('Countable', new StdClass),
         );
+    }
+
+    public function testGetMockForAbstractClassWithNonAbstractClass()
+    {
+        $mock = $this->generator->getMockForAbstractClass($class = 'Bar');
+
+        $this->assertInstanceOf($class, $mock);
+        $this->assertNotEquals($class, $mockClass = get_class($mock));
+
+        $class   = new ReflectionClass($mockClass);
+        $methods = array();
+        foreach ($class->getMethods() as $method) {
+            if ($method->class == $mockClass && substr($method->name, 0, 10) != '__phpunit_')
+                $methods[] = $method->name;
+        }
+        $this->assertEquals(array('__clone', 'expects', 'method'), $methods);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_MockObject_Generator::getMockForTrait
+     * @expectedException PHPUnit_Framework_Exception
+     * @expectedExceptionMessage Argument #1 (No Value) of PHPUnit_Framework_MockObject_Generator::getMockForTrait() must be a string
+     */
+    public function testGetMockForTraitWithInvalidTraitName()
+    {
+        $this->generator->getMockForTrait(false);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_MockObject_Generator::getMockForTrait
+     * @expectedException PHPUnit_Framework_Exception
+     * @expectedExceptionMessage Argument #3 (No Value) of PHPUnit_Framework_MockObject_Generator::getMockForTrait() must be a string
+     */
+    public function testGetMockForTraitWithInvalidMockClassName()
+    {
+        $this->generator->getMockForTrait('', array(), false);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_MockObject_Generator::getMockForTrait
+     * @expectedException PHPUnit_Framework_MockObject_RuntimeException
+     * @expectedExceptionMessage Trait "Framework_MockObject_GeneratorTest" does not exist.
+     */
+    public function testGetMockForTraitWithNonExistsTraitName()
+    {
+        $this->generator->getMockForTrait(get_class($this));
     }
 
     /**
@@ -196,5 +289,173 @@ class Framework_MockObject_GeneratorTest extends PHPUnit_Framework_TestCase
 
         $mock = $this->generator->getMock('SoapClient', array(), array(), '', false);
         $this->assertInstanceOf('SoapClient', $mock);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_MockObject_Generator::generateClassFromWsdl
+     */
+    public function testGenerateClassFromWsdlWithoutNeedleExtension()
+    {
+        if (extension_loaded('soap')) {
+            $this->markTestSkipped('Only for PHP without SOAP extension');
+        } else {
+            $this->setExpectedException('PHPUnit_Framework_MockObject_RuntimeException', 'The SOAP extension is required');
+            $this->generator->generateClassFromWsdl('', null);
+        }
+    }
+
+    /**
+     * @expectedException PHPUnit_Framework_Exception
+     * @expectedExceptionMessage Interface "Framework_MockObject_GeneratorTest" does not exist.
+     */
+    public function testGetMockGeneratorForNonExistsInterface()
+    {
+        $this->generator->getMock(array('Traversable', get_class($this)), null);
+    }
+
+    /**
+     * @expectedException PHPUnit_Framework_Exception
+     * @expectedExceptionMessage Duplicate method "offsetGet" not allowed.
+     */
+    public function testGetMockGeneratorForDuplicatedMethods()
+    {
+        $this->generator->getMock(array(get_class($this), 'ArrayAccess'), array('offsetGet'));
+    }
+
+    /**
+     * @expectedException PHPUnit_Framework_Exception
+     * @expectedExceptionMessage Class "Doctrine\Instantiator\Instantiator" is declared "final" and cannot be mocked.
+     */
+    public function testGetMockGeneratorForFinalClass()
+    {
+        $this->generator->getMock('Doctrine\Instantiator\Instantiator', null);
+    }
+
+    public function testGetMockForNonExistsClassWithNamespace()
+    {
+        $mock = $this->getMock($class = 'Bar\Foo\NotFound', array($method = 'barFoo'));
+        $mock->expects($this->once())->method($method)->willReturn($method);
+
+        $this->assertTrue(class_exists($class, false));
+        $this->assertTrue(method_exists($mock, $method));
+        $this->assertNotEquals($class, get_class($mock));
+        $this->assertInstanceOf($class, $mock);
+        $this->assertEquals($method, $mock->$method());
+    }
+
+    public function testGetMockWithOriginalMethods()
+    {
+        $mock = $this->generator->getMock('Mockable', null, array(0), '', true, true, true, false, true);
+
+        $this->assertAttributeEquals($args = array(0, null), 'constructorArgs', $mock);
+        $this->assertAttributeInstanceOf('Mockable', '__phpunit_originalObject', $mock);
+        $this->assertAttributeEquals($args, 'constructorArgs', $this->getObjectAttribute($mock, '__phpunit_originalObject'));
+
+        $mock->__phpunit_setOriginalObject(null);
+        foreach (get_class_methods('Mockable') as $method) {
+            if ($method[0] != '_')
+                $this->assertTrue($mock->$method());
+        }
+    }
+
+    public function testGetMockWithParentAsProxy()
+    {
+        $mock = $this->getMock('Bar', array('doSomething'), array(), '', false, true, true, false, true, 'parent');
+        $mock->expects($this->once())->method('doSomething')->with();
+
+        $this->assertAttributeEquals('parent', '__phpunit_originalObject', $mock);
+        $this->assertEquals('result', $mock->doSomethingElse(true));
+    }
+
+    public function testGetMockForInterfaceWithExtraMethod()
+    {
+        $mock = $this->getMock($class = 'AnotherInterface', array($method = 'foo'));
+        $mock->expects($this->once())->method($method)->willReturn($method);
+
+        $this->assertInstanceOf($class, $mock);
+        $this->assertTrue(method_exists($mock, $method));
+        $this->assertEquals($method, $mock->$method());
+    }
+
+    public function testGetMockForMultipleInterfaces()
+    {
+        $types = array('ClassWithStaticMethod', 'AnInterface', 'AnotherInterface');
+        $mock = $this->getMock($types, array($method = 'foo', 'staticMethod'));
+        $mock->expects($this->once())->method($method)->willReturn($method);
+
+        foreach ($types as $class)
+            $this->assertInstanceOf($class, $mock);
+
+        $this->assertTrue(method_exists($mock, $method));
+        $this->assertEquals($method, $mock->$method());
+
+        $this->setExpectedException('PHPUnit_Framework_MockObject_BadMethodCallException');
+        $mock->staticMethod();
+    }
+
+    public function testGetMockForReferenceMethod()
+    {
+        $mock = $this->getMock('Foo', array($method = 'doSomethingByRef'));
+        $mock->expects($this->once())->method($method)->with($this->logicalOr('baz', 'baz1'))->willReturnCallback(function (&$param) {
+            $param .= '1';
+            return $param;
+        });
+
+        $param = 'baz';
+        $result =& $mock->$method($param);
+
+        $this->assertEquals('baz1', $param);
+        $this->assertEquals($param, $result);
+
+        $result = 'baz2';
+        $this->assertNotEquals('baz2', $param);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_MockObject_Generator::getObjectForTrait
+     * @expectedException PHPUnit_Framework_Exception
+     * @expectedExceptionMessage Argument #1 (No Value) of PHPUnit_Framework_MockObject_Generator::getObjectForTrait() must be a string
+     */
+    public function testGetObjectForTraitWithInvalidTraitName()
+    {
+        $this->generator->getObjectForTrait(false);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_MockObject_Generator::getObjectForTrait
+     * @expectedException PHPUnit_Framework_Exception
+     * @expectedExceptionMessage Argument #3 (No Value) of PHPUnit_Framework_MockObject_Generator::getObjectForTrait() must be a string
+     */
+    public function testGetObjectForTraitWithInvalidMockClassName()
+    {
+        $this->generator->getObjectForTrait('', array(), false);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_MockObject_Generator::getObjectForTrait
+     * @expectedException PHPUnit_Framework_MockObject_RuntimeException
+     * @expectedExceptionMessage Trait "Framework_MockObject_GeneratorTest" does not exist.
+     */
+    public function testGetObjectForTraitWithNonExistsTraitName()
+    {
+        $this->generator->getObjectForTrait(get_class($this));
+    }
+
+    /**
+     * @covers PHPUnit_Framework_MockObject_Generator::getObjectForTrait
+     * @requires PHP 5.4.0
+     * @runInSeparateProcess
+     */
+    public function testGetObjectForTrait()
+    {
+        if (!class_exists($trait = 'FooTrait', false)) {
+            eval("trait $trait { public function foo() { return true; } }");
+        }
+
+        $object = $this->generator->getObjectForTrait($trait, array(), $class = 'NonMockTrait');
+        $this->assertInstanceOf($class, $object);
+
+        $this->assertTrue(method_exists($object, $method = 'foo'));
+        $this->assertTrue($object->$method());
     }
 }

--- a/tests/MockObject/interface.phpt
+++ b/tests/MockObject/interface.phpt
@@ -22,7 +22,7 @@ $mock = $generator->generate(
 print $mock['code'];
 ?>
 --EXPECTF--
-class MockFoo implements PHPUnit_Framework_MockObject_MockObject, Foo
+class MockFoo implements Foo, PHPUnit_Framework_MockObject_MockObject
 {
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;

--- a/tests/MockObject/namespaced_interface.phpt
+++ b/tests/MockObject/namespaced_interface.phpt
@@ -24,7 +24,7 @@ $mock = $generator->generate(
 print $mock['code'];
 ?>
 --EXPECTF--
-class MockFoo implements PHPUnit_Framework_MockObject_MockObject, NS\Foo
+class MockFoo implements NS\Foo, PHPUnit_Framework_MockObject_MockObject
 {
     private $__phpunit_invocationMocker;
     private $__phpunit_originalObject;

--- a/tests/MockObject/namespaced_mock_class_name.phpt
+++ b/tests/MockObject/namespaced_mock_class_name.phpt
@@ -1,0 +1,345 @@
+--TEST--
+PHPUnit_Framework_MockObject_Generator::generate('IteratorAggregate', array('foo'), 'Bar\Foo\Container', TRUE, TRUE, FALSE)
+--FILE--
+<?php
+require __DIR__ . '/../../vendor/autoload.php';
+
+$generator = new \PHPUnit_Framework_MockObject_Generator;
+
+$mock = $generator->generate('IteratorAggregate', array('foo'), 'Bar\Foo\Container', TRUE, TRUE, FALSE);
+print $mock['code'];
+
+$mock = $generator->generate('NotFoundClass', array('foo'), 'NS\MockNotFound', TRUE, TRUE);
+print "\n\n" . $mock['code'];
+
+$mock = $generator->generate(array('NS\NotFoundClass', 'Serializable', 'IteratorAggregate'), array('foo'), 'Bar\Foo\MockNotFound', TRUE, TRUE, FALSE);
+print "\n\n" . $mock['code'];
+?>
+--EXPECTF--
+namespace Bar\Foo {
+
+class Container implements \IteratorAggregate, \PHPUnit_Framework_MockObject_MockObject
+{
+    private $__phpunit_invocationMocker;
+    private $__phpunit_originalObject;
+
+    public function __clone()
+    {
+        $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
+    }
+
+    public function getIterator()
+    {
+        $arguments = array();
+        $count     = func_num_args();
+
+        if ($count > 0) {
+            $_arguments = func_get_args();
+
+            for ($i = 0; $i < $count; $i++) {
+                $arguments[] = $_arguments[$i];
+            }
+        }
+
+        $result = $this->__phpunit_getInvocationMocker()->invoke(
+          new \PHPUnit_Framework_MockObject_Invocation_Object(
+            'IteratorAggregate', 'getIterator', $arguments, $this, FALSE
+          )
+        );
+
+        return $result;
+    }
+
+    public function foo()
+    {
+        $arguments = array();
+        $count     = func_num_args();
+
+        if ($count > 0) {
+            $_arguments = func_get_args();
+
+            for ($i = 0; $i < $count; $i++) {
+                $arguments[] = $_arguments[$i];
+            }
+        }
+
+        $result = $this->__phpunit_getInvocationMocker()->invoke(
+          new \PHPUnit_Framework_MockObject_Invocation_Object(
+            'IteratorAggregate', 'foo', $arguments, $this, FALSE
+          )
+        );
+
+        return $result;
+    }
+
+    public function expects(\PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    {
+        return $this->__phpunit_getInvocationMocker()->expects($matcher);
+    }
+
+    public function method()
+    {
+        $any = new \PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
+    public function __phpunit_setOriginalObject($originalObject)
+    {
+        $this->__phpunit_originalObject = $originalObject;
+    }
+
+    public function __phpunit_getInvocationMocker()
+    {
+        if ($this->__phpunit_invocationMocker === NULL) {
+            $this->__phpunit_invocationMocker = new \PHPUnit_Framework_MockObject_InvocationMocker;
+        }
+
+        return $this->__phpunit_invocationMocker;
+    }
+
+    public function __phpunit_hasMatchers()
+    {
+        return $this->__phpunit_getInvocationMocker()->hasMatchers();
+    }
+
+    public function __phpunit_verify()
+    {
+        $this->__phpunit_getInvocationMocker()->verify();
+        $this->__phpunit_invocationMocker = NULL;
+    }
+}
+
+}
+
+
+namespace {
+
+class NotFoundClass
+{
+}
+
+}
+
+namespace NS {
+
+class MockNotFound extends \NotFoundClass implements \PHPUnit_Framework_MockObject_MockObject
+{
+    private $__phpunit_invocationMocker;
+    private $__phpunit_originalObject;
+
+    public function __clone()
+    {
+        $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
+    }
+
+    public function foo()
+    {
+        $arguments = array();
+        $count     = func_num_args();
+
+        if ($count > 0) {
+            $_arguments = func_get_args();
+
+            for ($i = 0; $i < $count; $i++) {
+                $arguments[] = $_arguments[$i];
+            }
+        }
+
+        $result = $this->__phpunit_getInvocationMocker()->invoke(
+          new \PHPUnit_Framework_MockObject_Invocation_Object(
+            'NotFoundClass', 'foo', $arguments, $this, TRUE
+          )
+        );
+
+        return $result;
+    }
+
+    public function expects(\PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    {
+        return $this->__phpunit_getInvocationMocker()->expects($matcher);
+    }
+
+    public function method()
+    {
+        $any = new \PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
+    public function __phpunit_setOriginalObject($originalObject)
+    {
+        $this->__phpunit_originalObject = $originalObject;
+    }
+
+    public function __phpunit_getInvocationMocker()
+    {
+        if ($this->__phpunit_invocationMocker === NULL) {
+            $this->__phpunit_invocationMocker = new \PHPUnit_Framework_MockObject_InvocationMocker;
+        }
+
+        return $this->__phpunit_invocationMocker;
+    }
+
+    public function __phpunit_hasMatchers()
+    {
+        return $this->__phpunit_getInvocationMocker()->hasMatchers();
+    }
+
+    public function __phpunit_verify()
+    {
+        $this->__phpunit_getInvocationMocker()->verify();
+        $this->__phpunit_invocationMocker = NULL;
+    }
+}
+
+}
+
+
+namespace NS {
+
+class NotFoundClass
+{
+}
+
+}
+
+namespace Bar\Foo {
+
+class MockNotFound extends \NS\NotFoundClass implements \Serializable, \IteratorAggregate, \PHPUnit_Framework_MockObject_MockObject
+{
+    private $__phpunit_invocationMocker;
+    private $__phpunit_originalObject;
+
+    public function __clone()
+    {
+        $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
+    }
+
+    public function foo()
+    {
+        $arguments = array();
+        $count     = func_num_args();
+
+        if ($count > 0) {
+            $_arguments = func_get_args();
+
+            for ($i = 0; $i < $count; $i++) {
+                $arguments[] = $_arguments[$i];
+            }
+        }
+
+        $result = $this->__phpunit_getInvocationMocker()->invoke(
+          new \PHPUnit_Framework_MockObject_Invocation_Object(
+            'NS\NotFoundClass', 'foo', $arguments, $this, FALSE
+          )
+        );
+
+        return $result;
+    }
+
+    public function serialize()
+    {
+        $arguments = array();
+        $count     = func_num_args();
+
+        if ($count > 0) {
+            $_arguments = func_get_args();
+
+            for ($i = 0; $i < $count; $i++) {
+                $arguments[] = $_arguments[$i];
+            }
+        }
+
+        $result = $this->__phpunit_getInvocationMocker()->invoke(
+          new \PHPUnit_Framework_MockObject_Invocation_Object(
+            'Serializable', 'serialize', $arguments, $this, FALSE
+          )
+        );
+
+        return $result;
+    }
+
+    public function unserialize($serialized)
+    {
+        $arguments = array($serialized);
+        $count     = func_num_args();
+
+        if ($count > 1) {
+            $_arguments = func_get_args();
+
+            for ($i = 1; $i < $count; $i++) {
+                $arguments[] = $_arguments[$i];
+            }
+        }
+
+        $result = $this->__phpunit_getInvocationMocker()->invoke(
+          new \PHPUnit_Framework_MockObject_Invocation_Object(
+            'Serializable', 'unserialize', $arguments, $this, FALSE
+          )
+        );
+
+        return $result;
+    }
+
+    public function getIterator()
+    {
+        $arguments = array();
+        $count     = func_num_args();
+
+        if ($count > 0) {
+            $_arguments = func_get_args();
+
+            for ($i = 0; $i < $count; $i++) {
+                $arguments[] = $_arguments[$i];
+            }
+        }
+
+        $result = $this->__phpunit_getInvocationMocker()->invoke(
+          new \PHPUnit_Framework_MockObject_Invocation_Object(
+            'IteratorAggregate', 'getIterator', $arguments, $this, FALSE
+          )
+        );
+
+        return $result;
+    }
+
+    public function expects(\PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    {
+        return $this->__phpunit_getInvocationMocker()->expects($matcher);
+    }
+
+    public function method()
+    {
+        $any = new \PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
+    public function __phpunit_setOriginalObject($originalObject)
+    {
+        $this->__phpunit_originalObject = $originalObject;
+    }
+
+    public function __phpunit_getInvocationMocker()
+    {
+        if ($this->__phpunit_invocationMocker === NULL) {
+            $this->__phpunit_invocationMocker = new \PHPUnit_Framework_MockObject_InvocationMocker;
+        }
+
+        return $this->__phpunit_invocationMocker;
+    }
+
+    public function __phpunit_hasMatchers()
+    {
+        return $this->__phpunit_getInvocationMocker()->hasMatchers();
+    }
+
+    public function __phpunit_verify()
+    {
+        $this->__phpunit_getInvocationMocker()->verify();
+        $this->__phpunit_invocationMocker = NULL;
+    }
+}
+
+}

--- a/tests/MockObject/proxy.phpt
+++ b/tests/MockObject/proxy.phpt
@@ -47,13 +47,13 @@ class ProxyFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
             }
         }
 
-        $this->__phpunit_getInvocationMocker()->invoke(
+        $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
             'Foo', 'bar', $arguments, $this, TRUE
           )
         );
 
-        return call_user_func_array(array($this->__phpunit_originalObject, "bar"), $arguments);
+        return isset($result) ? $result : call_user_func_array(array($this->__phpunit_originalObject, 'bar'), $arguments);
     }
 
     public function baz(Foo $foo)
@@ -69,13 +69,13 @@ class ProxyFoo extends Foo implements PHPUnit_Framework_MockObject_MockObject
             }
         }
 
-        $this->__phpunit_getInvocationMocker()->invoke(
+        $result = $this->__phpunit_getInvocationMocker()->invoke(
           new PHPUnit_Framework_MockObject_Invocation_Object(
             'Foo', 'baz', $arguments, $this, TRUE
           )
         );
 
-        return call_user_func_array(array($this->__phpunit_originalObject, "baz"), $arguments);
+        return isset($result) ? $result : call_user_func_array(array($this->__phpunit_originalObject, 'baz'), $arguments);
     }
 
     public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)

--- a/tests/_fixture/Bar.php
+++ b/tests/_fixture/Bar.php
@@ -3,6 +3,11 @@ class Bar
 {
     public function doSomethingElse()
     {
+        return $this->doSomething();
+    }
+
+    protected function doSomething()
+    {
         return 'result';
     }
 }

--- a/tests/_fixture/Foo.php
+++ b/tests/_fixture/Foo.php
@@ -5,4 +5,9 @@ class Foo
     {
         return $bar->doSomethingElse();
     }
+
+    public function &doSomethingByRef(&$a = null)
+    {
+        return $a;
+    }
 }


### PR DESCRIPTION
* Fix `Generator` class to allow mock with an array of types such as ['interface1', 'interface2'], ['class', 'interface1', 'interface2']
* Support 'parent' as `proxyTarget` to mock alternate methods correctly
* Add more unit-tests to cover classes `Generator`, `MockBuilder`
* Support `mockClassName` within a namespace, e.g. `$this->getMock(['NS\Foo', 'ArrayAccess'], ['foo'], [], 'Bar\Foo\MockFoo');`
* Support proxied mocking with invocation return instead of original method if invocation result is not null